### PR TITLE
Remove redundant news headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,23 +284,13 @@
                     <div class="news-item fade-in">
                         <div class="news-date">2025.05</div>
                         <div class="news-content">
-                            <h3 data-i18n="news_research">研究成果發表</h3>
                             <p data-i18n="news_achievement">恭喜王湘雯同學於日本千葉舉辦的2025年地球惑星科學聯合大會(JpGU)發表研究成果！發表題目為: A New Analytical Solution for Thermal Response Tests Considering Finite Borehole Radius and Grout Heat Capacity</p>
-                            <div class="news-tags">
-                                <span class="tag" data-i18n="news_conference">國際會議</span>
-                                <span class="tag">JpGU</span>
-                                <span class="tag" data-i18n="news_research">研究成果</span>
-                            </div>
                         </div>
                     </div>
                     <div class="news-item fade-in">
-                        <div class="news-date">2025.066</div>
+                        <div class="news-date">2025.06</div>
                         <div class="news-content">
-                            <h3 data-i18n="news_research">研究成果發表</h3>
                             <p data-i18n="news_submission">王湘雯同學已將研究成果投稿至Renewable Energy (IF: 9.0)</p>
-                            <div class="news-tags">
-                                <span class="tag" data-i18n="news_research">研究成果</span>
-                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove extra news headings and tags for Wang Xiangwen's achievements
- fix date typo for June news item

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e0988cfb4832cbb8d9912d1d819c1