### PR TITLE
Redesign homepage around research group identity

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -51,6 +51,9 @@ Training, Network, Open Tools, Glossary, Explain­ers, and About remain availabl
 ## Media rules
 
 - Team photographs are real project or conference images with specific alt text and captions.
+- The homepage hero is one full-bleed team photograph with the research statement set directly over the image. It is not a split text/media layout and the copy is not enclosed in a card.
+- The hero's pumping-test trace is explicitly labelled as conceptual. It may explain the sequence from pumping to measured drawdown and interpretation, but it must not imply that a schematic curve is field data.
+- Hero motion uses GSAP only to reveal existing content and draw the conceptual trace. The static HTML/SVG is complete without JavaScript, and `prefers-reduced-motion` leaves every element visible in its final state.
 - The hero image is eager; the activity mosaic and publication-film posters are lazy-loaded.
 - Video never autoplays. Its poster uses a dedicated play control; after activation, the native controls provide seeking, captions, volume, and full-screen playback. The no-JavaScript fallback retains native controls.
 - Manim output may be used only when the source paper or bounded concept ledger supports the storyboard. Public pages expose the finished visual and its evidence boundary, not private manuscript drafts.
@@ -68,6 +71,7 @@ Training, Network, Open Tools, Glossary, Explain­ers, and About remain availabl
 
 - Astro remains static-first. Do not add a client-side framework for the homepage unless the interaction cannot be expressed with native HTML/CSS.
 - Use real links, headings, lists, captions, and video controls before adding JavaScript.
+- Keep entrance motion between 0.5 and 1.4 seconds, animate transforms and opacity rather than layout properties, and avoid continuous decorative loops.
 - The publication-film player is a reusable progressive-enhancement primitive: poster and native controls are the baseline, while JavaScript replaces the resting controls with one keyboard-operable play button and restores native controls after activation.
 - Keyboard focus must be visible. Text and controls must meet WCAG 2.2 AA contrast. Reduced-motion users receive no transform or autoplay effects.
 - Use the selected information-architecture, hierarchy, type, colour, motion, and critique guidance from `Owl-Listener/designer-skills` as design review prompts, not as a reason to copy a template.

--- a/src/components/home/HomeResearchHero.astro
+++ b/src/components/home/HomeResearchHero.astro
@@ -1,0 +1,143 @@
+---
+import "./HomeResearchHero.css";
+const base = import.meta.env.BASE_URL.endsWith("/") ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
+const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
+const imageVariant = (path: string, width: number, extension: "avif" | "webp") =>
+  path.replace(/\.jpg$/i, `-${width}.${extension}`);
+const imageSrcset = (path: string, extension: "avif" | "webp") =>
+  [640, 960, 1440]
+    .map((width) => `${withBase(imageVariant(path, width, extension))} ${width}w`)
+    .join(", ");
+const heroImage = "/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg";
+---
+
+<div class="home-hero-system" data-home-hero>
+<section class="research-hero" aria-labelledby="home-title">
+  <figure class="research-hero__media">
+    <picture>
+      <source type="image/avif" srcset={imageSrcset(heroImage, "avif")} sizes="100vw" />
+      <source type="image/webp" srcset={imageSrcset(heroImage, "webp")} sizes="100vw" />
+      <img
+        class="research-hero__image"
+        src={withBase(heroImage)}
+        alt="Groundwater research team outside the JpGU 2026 venue."
+        width="1477"
+        height="1108"
+        fetchpriority="high"
+        decoding="async"
+      />
+    </picture>
+    <figcaption>JpGU 2026 · Chiba, Japan</figcaption>
+  </figure>
+
+  <div class="home-shell research-hero__content">
+    <div class="research-hero__copy">
+      <p class="research-hero__kicker" data-hero-reveal>Groundwater hydraulics · memory · decision</p>
+      <h1 id="home-title" data-hero-reveal>Groundwater responses leave traces in time.</h1>
+      <p class="research-hero__lede" data-hero-reveal>
+        We interpret aquifer tests, groundwater memory, and subsurface thermal systems for decisions that must
+        withstand uncertainty.
+      </p>
+      <div class="research-hero__actions" data-hero-reveal>
+        <a class="research-hero__button research-hero__button--solid" href={withBase("/projects/")}>
+          Explore the research <span aria-hidden="true">→</span>
+        </a>
+        <a class="research-hero__button research-hero__button--line" href={withBase("/collaborate/")}>
+          Discuss a collaboration
+        </a>
+      </div>
+      <p class="research-hero__note" data-hero-reveal>
+        Led by Ying-Fan Lin · analytical well hydraulics · transformation uncertainty
+      </p>
+    </div>
+
+  </div>
+</section>
+
+<section class="hydraulic-trace-band" aria-label="From pumping history to groundwater decision">
+  <div class="home-shell hydraulic-trace-band__inner">
+    <aside class="hydraulic-trace" aria-labelledby="hydraulic-trace-title" data-hero-reveal>
+      <div class="hydraulic-trace__heading">
+        <div>
+          <p>Conceptual pumping-test trace</p>
+          <h2 id="hydraulic-trace-title">A response is measured. A parameter is interpreted.</h2>
+        </div>
+        <span>Not field data</span>
+      </div>
+      <svg viewBox="0 0 640 156" role="img" aria-labelledby="trace-svg-title trace-svg-description">
+        <title id="trace-svg-title">Conceptual pumping and drawdown time series</title>
+        <desc id="trace-svg-description">
+          A step change in pumping is followed by a smooth drawdown response. The illustration is conceptual and does
+          not represent field observations.
+        </desc>
+        <g class="hydraulic-trace__grid" aria-hidden="true">
+          <line x1="92" y1="26" x2="620" y2="26"></line>
+          <line x1="92" y1="76" x2="620" y2="76"></line>
+          <line x1="92" y1="126" x2="620" y2="126"></line>
+        </g>
+        <text x="0" y="32">Q(t)</text>
+        <text x="0" y="132">s(t)</text>
+        <path class="hydraulic-trace__forcing" data-trace-path d="M92 26 H218 V60 H620"></path>
+        <path
+          class="hydraulic-trace__response"
+          data-trace-path
+          d="M92 126 C148 126 184 125 218 120 C278 111 309 96 357 86 C426 72 501 68 620 66"
+        ></path>
+        <circle class="hydraulic-trace__point hydraulic-trace__point--forcing" cx="218" cy="60" r="4"></circle>
+        <circle class="hydraulic-trace__point hydraulic-trace__point--response" cx="357" cy="86" r="4"></circle>
+      </svg>
+      <ol class="hydraulic-trace__steps">
+        <li><span>01</span><strong>Pumping history</strong></li>
+        <li><span>02</span><strong>Measured drawdown</strong></li>
+        <li><span>03</span><strong>Model interpretation</strong></li>
+        <li><span>04</span><strong>Decision</strong></li>
+      </ol>
+    </aside>
+  </div>
+</section>
+</div>
+
+<script>
+  import { gsap } from "gsap";
+
+  let heroContext: gsap.Context | undefined;
+  let heroMedia: gsap.MatchMedia | undefined;
+
+  const clearHeroMotion = () => {
+    heroMedia?.revert();
+    heroContext?.revert();
+    heroMedia = undefined;
+    heroContext = undefined;
+  };
+
+  const mountHeroMotion = () => {
+    const hero = document.querySelector<HTMLElement>("[data-home-hero]");
+    if (!hero || hero.dataset.motionReady === "true") return;
+
+    clearHeroMotion();
+    hero.dataset.motionReady = "true";
+    heroContext = gsap.context(() => {
+      heroMedia = gsap.matchMedia();
+      heroMedia.add("(prefers-reduced-motion: no-preference)", () => {
+        const paths = Array.from(hero.querySelectorAll<SVGPathElement>("[data-trace-path]"));
+        paths.forEach((path) => {
+          const length = path.getTotalLength();
+          gsap.set(path, { strokeDasharray: length, strokeDashoffset: length });
+        });
+
+        const timeline = gsap.timeline({ defaults: { ease: "power2.out" } });
+        timeline
+          .from(".research-hero__image", { scale: 1.035, duration: 1.4, ease: "power1.out" })
+          .from("[data-hero-reveal]", { autoAlpha: 0, y: 16, duration: 0.62, stagger: 0.08 }, 0.08)
+          .to(paths, { strokeDashoffset: 0, duration: 0.75, stagger: 0.1, ease: "power1.inOut" }, 0.4)
+          .from(".hydraulic-trace__point", { autoAlpha: 0, scale: 0.5, duration: 0.32, stagger: 0.12 }, 0.95);
+
+        return () => timeline.kill();
+      });
+    }, hero);
+  };
+
+  mountHeroMotion();
+  document.addEventListener("astro:page-load", mountHeroMotion);
+  document.addEventListener("astro:before-swap", clearHeroMotion);
+</script>

--- a/src/components/home/HomeResearchHero.css
+++ b/src/components/home/HomeResearchHero.css
@@ -1,0 +1,291 @@
+  .research-hero {
+    background: #14232b;
+    border-bottom: 1px solid var(--home-rule);
+    color: #fff;
+    isolation: isolate;
+    min-height: clamp(580px, calc(100svh - 280px), 720px);
+    overflow: hidden;
+    position: relative;
+  }
+
+  .research-hero__media,
+  .research-hero__media picture,
+  .research-hero__media::after {
+    inset: 0;
+    position: absolute;
+  }
+
+  .research-hero__media { margin: 0; z-index: -1; }
+
+  .research-hero__media picture { display: block; }
+
+  .research-hero__media::after {
+    background:
+      linear-gradient(90deg, rgb(10 24 30 / 0.96) 0%, rgb(10 24 30 / 0.82) 42%, rgb(10 24 30 / 0.26) 76%),
+      linear-gradient(0deg, rgb(10 24 30 / 0.74) 0%, transparent 52%);
+    content: "";
+    pointer-events: none;
+  }
+
+  .research-hero__image {
+    height: 100%;
+    object-fit: cover;
+    object-position: 57% 48%;
+    transform-origin: center;
+    width: 100%;
+  }
+
+  .research-hero__media figcaption {
+    background: rgb(10 24 30 / 0.84);
+    color: #fff;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    padding: 0.3rem 0.45rem;
+    position: absolute;
+    right: clamp(1rem, 3vw, 3rem);
+    text-transform: uppercase;
+    top: 1.25rem;
+    z-index: 1;
+  }
+
+  .research-hero__content {
+    align-items: center;
+    display: flex;
+    min-height: inherit;
+    padding-bottom: clamp(2.5rem, 5vw, 4.5rem);
+    padding-top: clamp(4.5rem, 9vw, 7.5rem);
+  }
+
+  .research-hero__copy {
+    align-self: center;
+    display: grid;
+    gap: 1.2rem;
+    max-width: 820px;
+    min-width: 0;
+  }
+
+  .research-hero__kicker,
+  .hydraulic-trace__heading p {
+    color: #a8d5d1;
+    font-size: 0.73rem;
+    font-weight: 760;
+    letter-spacing: 0.08em;
+    margin: 0;
+    text-transform: uppercase;
+  }
+
+  .research-hero h1 {
+    color: #fff;
+    font-size: 4rem;
+    letter-spacing: 0;
+    line-height: 0.98;
+    margin: 0;
+    max-width: 820px;
+    text-wrap: balance;
+  }
+
+  .research-hero__lede {
+    color: rgb(255 255 255 / 0.85);
+    font-size: clamp(1rem, 1.3vw, 1.16rem);
+    line-height: 1.68;
+    margin: 0;
+    max-width: 660px;
+  }
+
+  .research-hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+  }
+
+  .research-hero__button {
+    align-items: center;
+    border: 1px solid rgb(255 255 255 / 0.72);
+    display: inline-flex;
+    font-size: 0.86rem;
+    font-weight: 760;
+    gap: 0.65rem;
+    justify-content: center;
+    min-height: 3rem;
+    padding: 0.78rem 1rem;
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+  }
+
+  .research-hero__button:hover,
+  .research-hero__button:focus-visible {
+    transform: translateY(-2px);
+  }
+
+  .research-hero__button--solid {
+    background: #fff;
+    border-color: #fff;
+    color: #14232b;
+  }
+
+  .research-hero__button--line { color: #fff; }
+
+  .research-hero__button--line:hover,
+  .research-hero__button--line:focus-visible {
+    background: rgb(255 255 255 / 0.12);
+    border-color: #fff;
+  }
+
+  .research-hero__note {
+    border-left: 3px solid #d0a95c;
+    color: rgb(255 255 255 / 0.72);
+    font-size: 0.78rem;
+    line-height: 1.5;
+    margin: 0;
+    padding-left: 0.85rem;
+  }
+
+  .hydraulic-trace-band {
+    background: #14232b;
+    color: #fff;
+  }
+
+  .hydraulic-trace-band__inner {
+    padding-bottom: 2.2rem;
+    padding-top: 2.2rem;
+  }
+
+  .hydraulic-trace {
+    border-bottom: 1px solid rgb(255 255 255 / 0.32);
+    border-top: 1px solid rgb(255 255 255 / 0.32);
+    display: grid;
+    gap: 0.35rem 3.5rem;
+    grid-template-columns: minmax(250px, 0.62fr) minmax(0, 1.38fr);
+    padding: 1.25rem 0 1.1rem;
+  }
+
+  .hydraulic-trace__heading {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    align-items: start;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+  }
+
+  .hydraulic-trace__heading h2 {
+    color: #fff;
+    font-family: inherit;
+    font-size: 1rem;
+    line-height: 1.35;
+    margin: 0.35rem 0 0;
+    max-width: 330px;
+  }
+
+  .hydraulic-trace__heading > span {
+    border: 1px solid rgb(255 255 255 / 0.4);
+    color: rgb(255 255 255 / 0.72);
+    font-size: 0.62rem;
+    letter-spacing: 0.05em;
+    padding: 0.3rem 0.4rem;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .hydraulic-trace svg {
+    grid-column: 2;
+    grid-row: 1;
+    display: block;
+    height: auto;
+    margin-top: 0.35rem;
+    overflow: visible;
+    width: 100%;
+  }
+
+  .hydraulic-trace text {
+    fill: rgb(255 255 255 / 0.68);
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+    font-size: 18px;
+  }
+
+  .hydraulic-trace__grid line {
+    stroke: rgb(255 255 255 / 0.16);
+    stroke-width: 1;
+  }
+
+  .hydraulic-trace__forcing,
+  .hydraulic-trace__response {
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 4;
+  }
+
+  .hydraulic-trace__forcing { stroke: #a8d5d1; }
+  .hydraulic-trace__response { stroke: #d0a95c; }
+  .hydraulic-trace__point--forcing { fill: #a8d5d1; }
+  .hydraulic-trace__point--response { fill: #d0a95c; }
+
+  .hydraulic-trace__steps {
+    grid-column: 2;
+    grid-row: 2;
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    list-style: none;
+    margin: 0.15rem 0 0;
+    padding: 0;
+  }
+
+  .hydraulic-trace__steps li {
+    display: grid;
+    gap: 0.2rem;
+  }
+
+  .hydraulic-trace__steps span {
+    color: #a8d5d1;
+    font-size: 0.62rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .hydraulic-trace__steps strong {
+    color: rgb(255 255 255 / 0.8);
+    font-size: 0.67rem;
+    font-weight: 650;
+    line-height: 1.3;
+  }
+
+  @media (max-width: 900px) {
+    .research-hero { min-height: clamp(560px, calc(100svh - 180px), 680px); }
+    .research-hero__content { min-height: inherit; padding-bottom: 2.5rem; padding-top: 4.5rem; }
+    .research-hero__copy { max-width: 680px; }
+    .research-hero h1 { font-size: 3.4rem; }
+    .hydraulic-trace { gap: 1.2rem; grid-template-columns: 1fr; }
+    .hydraulic-trace__heading,
+    .hydraulic-trace svg,
+    .hydraulic-trace__steps {
+      grid-column: 1;
+      grid-row: auto;
+    }
+    .research-hero__media::after {
+      background:
+        linear-gradient(90deg, rgb(10 24 30 / 0.93) 0%, rgb(10 24 30 / 0.64) 68%, rgb(10 24 30 / 0.34) 100%),
+        linear-gradient(0deg, rgb(10 24 30 / 0.88) 0%, transparent 60%);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .research-hero { min-height: clamp(600px, calc(100svh - 150px), 660px); }
+    .research-hero__content {
+      min-height: inherit;
+      padding-bottom: 2rem;
+      padding-top: 3rem;
+    }
+    .research-hero h1 { font-size: 2.3rem; max-width: 100%; }
+    .research-hero__image { object-position: 72% 46%; }
+    .research-hero__media figcaption { display: none; }
+    .research-hero__actions { align-items: stretch; flex-direction: column; }
+    .research-hero__button { width: 100%; }
+    .hydraulic-trace__heading { align-items: start; flex-direction: column; }
+    .hydraulic-trace__steps { grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: 0.7rem; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .research-hero__button { transition: none; }
+    .research-hero__button:hover,
+    .research-hero__button:focus-visible { transform: none; }
+  }

--- a/src/components/research/FluxGradientAsynchronyRive.astro
+++ b/src/components/research/FluxGradientAsynchronyRive.astro
@@ -38,7 +38,7 @@ const riveSrc = hasRiveAsset ? `${base}animations/flux-gradient-asynchrony.riv` 
         data-rive-canvas
         width="860"
         height="420"
-        aria-label="Rive flux-gradient asynchrony state machine"
+        aria-label="Flux-gradient asynchrony conceptual schematic"
         hidden
       ></canvas>
       <svg data-rive-fallback viewBox="0 0 860 420" role="img" aria-labelledby="rive-asynchrony-svg-title rive-asynchrony-svg-desc">
@@ -96,7 +96,7 @@ const riveSrc = hasRiveAsset ? `${base}animations/flux-gradient-asynchrony.riv` 
         </div>
         <div>
           <dt>Scope</dt>
-          <dd data-rive-runtime-status>Conceptual state-machine schematic; not a calibrated aquifer mechanism diagnosis.</dd>
+          <dd data-rive-runtime-status>This schematic illustrates three conceptual response states; it is not a calibrated aquifer-mechanism diagnosis.</dd>
         </div>
       </dl>
     </div>
@@ -200,7 +200,7 @@ const riveSrc = hasRiveAsset ? `${base}animations/flux-gradient-asynchrony.riv` 
     try {
       const probe = await fetch(src, { method: "HEAD", cache: "no-cache" });
       if (!probe.ok) {
-        if (status) status.textContent = "Conceptual state-machine schematic; not a calibrated aquifer mechanism diagnosis.";
+        if (status) status.textContent = "This schematic illustrates three conceptual response states; it is not a calibrated aquifer-mechanism diagnosis.";
         return;
       }
 
@@ -221,12 +221,12 @@ const riveSrc = hasRiveAsset ? `${base}animations/flux-gradient-asynchrony.riv` 
             riveInputsByRoot.set(root, asynchronyInput);
             syncRiveInput(root, Number(input.value));
           }
-          if (status) status.textContent = "Conceptual state-machine schematic; not a calibrated aquifer mechanism diagnosis.";
+          if (status) status.textContent = "This schematic illustrates three conceptual response states; it is not a calibrated aquifer-mechanism diagnosis.";
         },
         onLoadError: () => {
           canvas.hidden = true;
           fallback?.removeAttribute("hidden");
-          if (status) status.textContent = "Conceptual state-machine schematic; not a calibrated aquifer mechanism diagnosis.";
+          if (status) status.textContent = "This schematic illustrates three conceptual response states; it is not a calibrated aquifer-mechanism diagnosis.";
         },
       });
       activeRiveInstances.add(rive);
@@ -234,7 +234,7 @@ const riveSrc = hasRiveAsset ? `${base}animations/flux-gradient-asynchrony.riv` 
       console.warn("Asynchrony visual used the SVG schematic", error);
       canvas.hidden = true;
       fallback?.removeAttribute("hidden");
-      if (status) status.textContent = "Conceptual state-machine schematic; not a calibrated aquifer mechanism diagnosis.";
+      if (status) status.textContent = "This schematic illustrates three conceptual response states; it is not a calibrated aquifer-mechanism diagnosis.";
     }
   }
 

--- a/src/components/research/LaggingPumpingTestDemo.astro
+++ b/src/components/research/LaggingPumpingTestDemo.astro
@@ -108,9 +108,10 @@ const presets = [
       </article>
     </div>
 
-    <div class="ldl-demo__equation" aria-label="Calculation note">
+    <details class="ldl-demo__equation">
+      <summary>Technical note: public demonstration scope</summary>
       <p>
-        Calculation note: this teaching model applies the Lin-Yeh lag operator to a
+        This teaching model applies the Lin-Yeh lag operator to a
         line-source leaky confined aquifer transfer function in Laplace space. The
         browser inverts the response with a 12-term Gaver-Stehfest algorithm and a
         Bessel K0 approximation. Wellbore storage and finite well radius are not
@@ -122,7 +123,7 @@ const presets = [
         cancel and the curve returns to the Classical Darcy response. Setting both to zero
         gives the Classical Darcy limit directly.
       </p>
-    </div>
+    </details>
   </div>
 </section>
 

--- a/src/components/research/LottieStatusMotion.astro
+++ b/src/components/research/LottieStatusMotion.astro
@@ -38,7 +38,7 @@ const lottieSrc = `${base}animations/decision-chain.lottie`;
       aria-label="Animated chain from measured response to model interpretation to use in engineering decisions"
     ></canvas>
     <figcaption data-dotlottie-status>
-      Conceptual motion graphic; not a calibrated aquifer simulation.
+      This animation illustrates the decision chain from measured response to engineering use; it is not a calibrated aquifer simulation.
     </figcaption>
   </figure>
   <div class="micro-motion__rail" aria-label="Animated model review states">
@@ -95,14 +95,14 @@ const lottieSrc = `${base}animations/decision-chain.lottie`;
         });
         activeLottiePlayers.add(player);
         player.addEventListener("load", () => {
-          if (status) status.textContent = "Conceptual motion graphic; not a calibrated aquifer simulation.";
+          if (status) status.textContent = "This animation illustrates the decision chain from measured response to engineering use; it is not a calibrated aquifer simulation.";
         });
         player.addEventListener("loadError", () => {
-          if (status) status.textContent = "Conceptual motion graphic; not a calibrated aquifer simulation.";
+          if (status) status.textContent = "This animation illustrates the decision chain from measured response to engineering use; it is not a calibrated aquifer simulation.";
         });
       } catch (error) {
         console.warn("dotLottie motion could not initialize", error);
-        if (status) status.textContent = "Conceptual motion graphic; not a calibrated aquifer simulation.";
+        if (status) status.textContent = "This animation illustrates the decision chain from measured response to engineering use; it is not a calibrated aquifer simulation.";
       }
     });
   }

--- a/src/components/research/ResearchHero.astro
+++ b/src/components/research/ResearchHero.astro
@@ -62,7 +62,7 @@ const hasVisualSlot = Astro.slots.has("visual");
     </div>
     <Card class="research-hero__panel">
       <CardHeader>
-        <Badge variant="outline" size="sm">Operating thesis</Badge>
+        <Badge variant="outline" size="sm">Research focus</Badge>
         <CardTitle>{thesisTitle}</CardTitle>
       </CardHeader>
       <CardContent>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,11 @@
 ---
 import { getCollection } from "astro:content";
+import HomeResearchHero from "../components/home/HomeResearchHero.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { absoluteUrl, siteRoot } from "../lib/seo";
 import members from "../data/members.generated.json";
 import publications from "../data/publications.generated.json";
+import { getPlainLanguage, getVisualStatus } from "../data/publicationPresentation";
 import { activityPhotos, studentPublicationIds } from "../data/groupSite";
 import { researchPrograms } from "../data/researchPrograms";
 
@@ -19,12 +21,14 @@ const imageVariant = (path: string, width: number, extension: "avif" | "webp") =
 const imageSrcset = (path: string, extension: "avif" | "webp") => [640, 960, 1440].map((width) => `${withBase(imageVariant(path, width, extension))} ${width}w`).join(", ");
 const rootUrl = siteRoot(Astro.site);
 const homeUrl = absoluteUrl("/", Astro.site);
-const selectedPublicationIds = ["2026-01-2", "2026-01-3", "2025-07-8", "2025-03-13", "2024-02-22", "2022-07-31"];
+const selectedPublicationIds = ["2026-01-2", "2026-01-3", "2025-07-8"];
 const selectedPublications = selectedPublicationIds
   .map((id) => publications.find((publication) => publication.id === id))
   .filter(Boolean);
 const publicRecords = publications.filter((publication) => ["published", "accepted"].includes(publication.status));
 const studentPublications = publications.filter((publication) => studentPublicationIds.includes(publication.id));
+const publicationMediaVersion = "20260716";
+const withMediaVersion = (path: string) => `${withBase(path)}?v=${publicationMediaVersion}`;
 const roleLabel: Record<string, string> = {
   team_role_pi: "Faculty",
   team_role_master: "Graduate student",
@@ -59,38 +63,68 @@ const homeSchema = [
   translatedPath="/zh/"
   pageClass="research-home"
 >
-  <section class="home-hero" aria-labelledby="home-title">
-    <div class="home-shell home-hero__grid">
-      <div class="home-hero__copy">
-        <p class="home-kicker">Lin Groundwater Hydraulics Group</p>
-        <h1 id="home-title">Groundwater responses leave traces in time.</h1>
-        <p class="home-hero__lede">
-          We develop analytical, numerical, and data-supported methods for interpreting aquifer tests,
-          transient groundwater signals, and groundwater-influenced thermal systems.
-        </p>
-        <div class="home-actions">
-          <a class="home-button home-button--dark" href={withBase("/projects/")}>Explore the research</a>
-          <a class="home-button home-button--line" href={withBase("/collaborate/")}>Discuss a collaboration</a>
+  <HomeResearchHero />
+
+  <section class="home-section home-team" aria-labelledby="team-title">
+    <div class="home-shell">
+      <div class="home-section-heading home-section-heading--split">
+        <div>
+          <p class="home-kicker">People and practice</p>
+          <h2 id="team-title">Research grows through shared technical work.</h2>
         </div>
-        <p class="home-hero__note">
-          Directed by Ying-Fan Lin · analytical well hydraulics · groundwater memory · decision-focused uncertainty
-        </p>
+        <a class="home-text-link" href={withBase("/team/")}>Meet the people <span aria-hidden="true">→</span></a>
       </div>
-      <figure class="home-hero__media">
-        <picture>
-          <source type="image/avif" srcset={imageSrcset("/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg", "avif")} sizes="(max-width: 900px) 100vw, 52vw" />
-          <source type="image/webp" srcset={imageSrcset("/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg", "webp")} sizes="(max-width: 900px) 100vw, 52vw" />
-          <img
-            src={withBase("/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg")}
-            alt="Groundwater research team outside the JpGU 2026 venue."
-            width="1477"
-            height="1108"
-            fetchpriority="high"
-            decoding="async"
-          />
-        </picture>
-        <figcaption>Team presence at JpGU 2026. Research is built in public exchange and careful technical work.</figcaption>
-      </figure>
+      <div class="home-team__grid">
+        <div class="home-team__people">
+          <p>
+            Conference exchange, student-led presentations, derivation, model comparison, and figure checking are part
+            of how the group develops research questions.
+          </p>
+          <ul>
+            {members.currentMembers.map((member) => (
+              <li>
+                <strong>{member.name.en}</strong>
+                <span>{roleLabel[member.roleKey] ?? "Research member"}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div class="home-team__photos">
+          {activityPhotos.map((photo, index) => (
+            <figure class={`team-photo team-photo--${index + 1}`}>
+              <picture>
+                <source type="image/avif" srcset={imageSrcset(photo.src, "avif")} sizes="(max-width: 640px) 100vw, 34vw" />
+                <source type="image/webp" srcset={imageSrcset(photo.src, "webp")} sizes="(max-width: 640px) 100vw, 34vw" />
+                <img src={withBase(photo.src)} alt={photo.alt} loading="lazy" decoding="async" />
+              </picture>
+              <figcaption>{photo.label}</figcaption>
+            </figure>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-section home-programs" aria-labelledby="programs-title">
+    <div class="home-shell">
+      <div class="home-section-heading">
+        <p class="home-kicker">One physical question · four research lines</p>
+        <h2 id="programs-title">When does the subsurface fail to respond instantaneously?</h2>
+        <p>The programme moves from analytical structure to field interpretation, then carries model disagreement into engineering decisions.</p>
+      </div>
+      <div class="home-program-list">
+        {researchPrograms.map((program) => (
+          <article class={`home-program home-program--${program.tone}`} id={program.id}>
+            <span class="home-program__number">{program.number}</span>
+            <div class="home-program__body">
+              <h3>{program.title}</h3>
+              <p>{program.description}</p>
+              <p class="home-program__evidence"><strong>Public record:</strong> {program.evidence}</p>
+            </div>
+            <a class="home-text-link" href={withBase(program.link)}>Open research line <span aria-hidden="true">→</span></a>
+          </article>
+        ))}
+      </div>
     </div>
   </section>
 
@@ -132,89 +166,52 @@ const homeSchema = [
     </div>
   </section>
 
-  <section class="home-section home-team" aria-labelledby="team-title">
-    <div class="home-shell">
-      <div class="home-section-heading home-section-heading--split">
-        <div>
-          <p class="home-kicker">People and practice</p>
-          <h2 id="team-title">The work is carried by a group, not a profile page.</h2>
-        </div>
-        <a class="home-text-link" href={withBase("/team/")}>Meet the people <span aria-hidden="true">→</span></a>
-      </div>
-      <div class="home-team__grid">
-        <div class="home-team__people">
-          <p>
-            Students and collaborators learn through derivation, model comparison, figure checking, and direct discussion
-            of what the data can support.
-          </p>
-          <ul>
-            {members.currentMembers.map((member) => (
-              <li>
-                <strong>{member.name.en}</strong>
-                <span>{roleLabel[member.roleKey] ?? "Research member"}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div class="home-team__photos">
-          {activityPhotos.map((photo, index) => (
-            <figure class={`team-photo team-photo--${index + 1}`}>
-              <picture>
-                <source type="image/avif" srcset={imageSrcset(photo.src, "avif")} sizes="(max-width: 640px) 100vw, 34vw" />
-                <source type="image/webp" srcset={imageSrcset(photo.src, "webp")} sizes="(max-width: 640px) 100vw, 34vw" />
-                <img src={withBase(photo.src)} alt={photo.alt} loading="lazy" decoding="async" />
-              </picture>
-              <figcaption>{photo.label}</figcaption>
-            </figure>
-          ))}
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="home-section home-programs" aria-labelledby="programs-title">
-    <div class="home-shell">
-      <div class="home-section-heading">
-        <p class="home-kicker">Research lines</p>
-        <h2 id="programs-title">Four questions organize the laboratory.</h2>
-        <p>Each line keeps its own evidence base while sharing one concern: how subsurface processes become defensible decisions.</p>
-      </div>
-      <div class="home-program-list">
-        {researchPrograms.map((program) => (
-          <article class={`home-program home-program--${program.tone}`} id={program.id}>
-            <span class="home-program__number">{program.number}</span>
-            <div class="home-program__body">
-              <h3>{program.title}</h3>
-              <p>{program.description}</p>
-              <p class="home-program__evidence"><strong>Public record:</strong> {program.evidence}</p>
-            </div>
-            <a class="home-text-link" href={withBase(program.link)}>Open research line <span aria-hidden="true">→</span></a>
-          </article>
-        ))}
-      </div>
-    </div>
-  </section>
-
   <section class="home-section home-publications" aria-labelledby="outputs-title">
     <div class="home-shell">
       <div class="home-section-heading home-section-heading--split">
         <div>
-          <p class="home-kicker">Selected outputs</p>
-          <h2 id="outputs-title">A publication record that remains searchable and inspectable.</h2>
-          <p>Visual abstracts now sit beside the corresponding paper record, with source notes and captions kept together on the publication page.</p>
+          <p class="home-kicker">Papers with visual explanations</p>
+          <h2 id="outputs-title">Read the result. Watch the mechanism.</h2>
+          <p>Each selected paper pairs a plain-language account with its source-bounded visual explanation.</p>
         </div>
         <a class="home-text-link" href={withBase("/publications/")}>Browse all publications <span aria-hidden="true">→</span></a>
       </div>
       <div class="home-publication-list">
         {selectedPublications.map((publication) => (
           <article>
-            <time datetime={String(publication?.year)}>{publication?.year}</time>
-            <div>
+            <div class="home-publication-list__copy">
+              <p class="home-publication-list__meta">
+                <time datetime={String(publication?.year)}>{publication?.year}</time>
+                <span>{publication?.venue}</span>
+              </p>
               <h3>{publication?.title.en}</h3>
-              <p>{publication?.authors}</p>
-              <span>{publication?.venue} · {publication?.status === "accepted" ? "Accepted" : "Published"}</span>
-              {publication?.publicRecord && <a href={publication.publicRecord} target="_blank" rel="noreferrer">View DOI record</a>}
+              <p class="home-publication-list__citation">{publication?.authors}</p>
+              <p class="home-publication-list__plain">{publication ? getPlainLanguage(publication) : ""}</p>
+              <p class="home-publication-list__links">
+                {publication?.publicRecord && <a href={publication.publicRecord} target="_blank" rel="noreferrer">DOI: {publication.doi}</a>}
+                <a href={withBase("/publications/")}>Publication archive</a>
+              </p>
             </div>
+            {publication && (() => {
+              const visual = getVisualStatus(publication);
+              return visual.kind === "available" && visual.film ? (
+                <figure class="home-publication-list__visual">
+                  <video
+                    controls
+                    preload="none"
+                    poster={withMediaVersion(visual.film.poster)}
+                    width="1280"
+                    height="720"
+                    aria-label={`Visual explanation for ${publication.title.en}`}
+                  >
+                    <source src={withMediaVersion(visual.film.video)} type="video/mp4" />
+                    {visual.film.captions && <track kind="captions" src={withMediaVersion(visual.film.captions)} srclang="en" label="English captions" default />}
+                    Your browser does not support the video element.
+                  </video>
+                  <figcaption>Visual explanation based on the published study · use full screen for figure labels · captions included</figcaption>
+                </figure>
+              ) : null;
+            })()}
           </article>
         ))}
       </div>
@@ -230,14 +227,14 @@ const homeSchema = [
     <div class="home-shell home-collaborate__grid">
       <div>
         <p class="home-kicker">Collaboration</p>
-        <h2 id="collaborate-title">Bring the response that does not fit the usual interpretation.</h2>
+        <h2 id="collaborate-title">Bring the forcing history, the observed response, and the decision at risk.</h2>
       </div>
       <div>
         <p>
-          Useful starting material includes an aquifer-test record, a recovery sequence, a TRT, a thermal or hydraulic
-          boundary question, and the decision variable that must be defended.
+          We work with groundwater, geotechnical, and subsurface-energy teams when interpretation changes what should
+          be built, operated, or monitored.
         </p>
-        <a class="home-button home-button--dark" href={withBase("/collaborate/")}>Send a technical brief</a>
+        <a class="home-button home-button--dark" href={withBase("/collaborate/")}>Send a technical brief <span aria-hidden="true">→</span></a>
       </div>
     </div>
   </section>
@@ -267,31 +264,59 @@ const homeSchema = [
   </section>
 </BaseLayout>
 
+<script>
+  import { gsap } from "gsap";
+
+  let homeRevealContext: gsap.Context | undefined;
+  let homeRevealObserver: IntersectionObserver | undefined;
+
+  const clearHomeReveals = () => {
+    homeRevealObserver?.disconnect();
+    homeRevealContext?.revert();
+    homeRevealObserver = undefined;
+    homeRevealContext = undefined;
+  };
+
+  const mountHomeReveals = () => {
+    const page = document.querySelector<HTMLElement>(".research-home");
+    if (!page || page.dataset.revealsReady === "true") return;
+    page.dataset.revealsReady = "true";
+
+    clearHomeReveals();
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const targets = Array.from(page.querySelectorAll<HTMLElement>(
+      ".home-section-heading, .home-team__photos, .home-program, .home-proof__numbers, .home-proof__grid, .home-publication-list article, .home-collaborate__grid",
+    ));
+
+    homeRevealContext = gsap.context(() => {
+      homeRevealObserver = new IntersectionObserver((entries, observer) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          gsap.from(entry.target, { autoAlpha: 0, y: 18, duration: 0.6, ease: "power2.out", clearProps: "transform,opacity,visibility" });
+          observer.unobserve(entry.target);
+        });
+      }, { rootMargin: "0px 0px -8%", threshold: 0.08 });
+      targets.forEach((target) => homeRevealObserver?.observe(target));
+    }, page);
+  };
+
+  mountHomeReveals();
+  document.addEventListener("astro:page-load", mountHomeReveals);
+  document.addEventListener("astro:before-swap", clearHomeReveals);
+</script>
+
 <style is:global>
-  .research-home { --home-ink: #14232b; --home-muted: #52636a; --home-paper: #f7f8f5; --home-blue: #0e6670; --home-red: #a14a36; --home-ochre: #a66f25; --home-rule: #d5dfdc; }
+  .research-home { --home-ink: #10252a; --home-muted: #52676c; --home-paper: #f6f8f5; --home-blue: #1f6f6d; --home-red: #a14a36; --home-ochre: #d1aa58; --home-rule: #c9d5d0; }
   .home-shell { width: min(1180px, calc(100% - 3rem)); margin: 0 auto; }
-  .home-hero { background: var(--home-paper); border-bottom: 1px solid var(--home-rule); }
-  .home-hero__grid { align-items: stretch; display: grid; grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr); min-height: min(720px, calc(100vh - 72px)); }
-  .home-hero__copy { align-content: center; display: grid; gap: 1.3rem; padding: 5rem 3rem 5rem 0; }
   .home-kicker { color: var(--home-blue); font-size: 0.76rem; font-weight: 750; letter-spacing: 0.08em; line-height: 1.4; margin: 0; text-transform: uppercase; }
-  .home-hero h1 { color: var(--home-ink); font-size: clamp(3.3rem, 5vw, 6.8rem); letter-spacing: 0; line-height: 0.96; max-width: 100%; }
-  .home-hero__lede { color: var(--home-muted); font-size: clamp(1.05rem, 1.45vw, 1.28rem); line-height: 1.7; max-width: 100%; }
-  .home-actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
   .home-button { align-items: center; border: 1px solid var(--home-ink); display: inline-flex; font-size: 0.9rem; font-weight: 700; justify-content: center; min-height: 3rem; padding: 0.8rem 1.05rem; transition: transform 160ms ease, background 160ms ease, color 160ms ease; }
   .home-button:hover, .home-button:focus-visible { transform: translateY(-2px); }
   .home-button--dark { background: var(--home-ink); color: #fff; }
-  .home-button--line { color: var(--home-ink); }
-  .home-button--line:hover, .home-button--line:focus-visible { background: #fff; }
-  .home-hero__note { border-left: 3px solid var(--home-ochre); color: var(--home-muted); font-size: 0.83rem; line-height: 1.55; margin: 0; max-width: 100%; padding-left: 0.9rem; }
-  .home-hero__media { align-self: stretch; margin: 0; min-height: 520px; position: relative; }
-  .home-hero__media::after { background: linear-gradient(90deg, rgb(20 35 43 / 0.22), transparent 28%), linear-gradient(0deg, rgb(20 35 43 / 0.3), transparent 36%); content: ""; inset: 0; pointer-events: none; position: absolute; }
-  .home-hero__media picture { display: block; height: 100%; }
-  .home-hero__media img { display: block; height: 100%; object-fit: cover; object-position: center; width: 100%; }
-  .home-hero__media figcaption { bottom: 1.2rem; color: #fff; font-size: 0.8rem; line-height: 1.45; max-width: 360px; padding: 0 1.4rem; position: absolute; right: 0; z-index: 1; }
-  .home-section { padding: 7.5rem 0; }
+  .home-section { padding: 7rem 0; }
   .home-section:nth-of-type(even) { background: #fff; }
   .home-section-heading { display: grid; gap: 0.8rem; max-width: 830px; }
-  .home-section-heading h2 { color: var(--home-ink); font-size: clamp(2.3rem, 4.3vw, 4.6rem); letter-spacing: 0; line-height: 1; }
+  .home-section-heading h2 { color: var(--home-ink); font-size: 3.8rem; letter-spacing: 0; line-height: 1.02; }
   .home-section-heading p:not(.home-kicker) { color: var(--home-muted); font-size: 1.06rem; line-height: 1.75; max-width: 720px; }
   .home-section-heading--split { align-items: end; display: flex; gap: 2rem; justify-content: space-between; max-width: none; }
   .home-section-heading--split > div { max-width: 830px; }
@@ -300,35 +325,43 @@ const homeSchema = [
   .home-proof__numbers { border-bottom: 1px solid var(--home-rule); border-top: 1px solid var(--home-rule); display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 3.5rem; }
   .home-proof__numbers div { display: grid; gap: 0.45rem; padding: 1.5rem 1.1rem 1.5rem 0; }
   .home-proof__numbers div + div { border-left: 1px solid var(--home-rule); padding-left: 1.1rem; }
-  .home-proof__numbers strong { color: var(--home-ink); font-size: clamp(2.6rem, 5vw, 5rem); font-weight: 650; letter-spacing: 0; line-height: 0.9; }
+  .home-proof { background: var(--home-ink) !important; color: #fff; }
+  .home-proof .home-kicker { color: #9ed7d1; }
+  .home-proof .home-section-heading h2, .home-proof .home-boundary-note h3, .home-proof .home-trajectory span { color: #fff; }
+  .home-proof .home-section-heading p:not(.home-kicker), .home-proof .home-proof__numbers span, .home-proof .home-trajectory small, .home-proof .home-boundary-note p:not(.home-kicker) { color: #c7d5d2; }
+  .home-proof .home-text-link, .home-proof .home-boundary-note a { color: #fff; }
+  .home-proof .home-proof__numbers, .home-proof .home-proof__numbers div + div, .home-proof .home-trajectory, .home-proof .home-trajectory li { border-color: rgb(255 255 255 / 0.24); }
+  .home-proof__numbers strong { color: var(--home-ochre); font-size: 4.5rem; font-weight: 650; letter-spacing: 0; line-height: 0.9; }
   .home-proof__numbers span { color: var(--home-muted); font-size: 0.88rem; line-height: 1.45; max-width: 170px; }
   .home-proof__grid { display: grid; gap: 5rem; grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.75fr); margin-top: 4.5rem; }
   .home-trajectory { border-top: 1px solid var(--home-rule); list-style: none; margin: 1.25rem 0 0; padding: 0; }
   .home-trajectory li { border-bottom: 1px solid var(--home-rule); display: grid; gap: 0.25rem; grid-template-columns: minmax(180px, 0.45fr) 1fr; padding: 1rem 0; }
   .home-trajectory span { color: var(--home-ink); font-weight: 700; }
   .home-trajectory small { color: var(--home-muted); font-size: 0.9rem; line-height: 1.55; }
-  .home-boundary-note { border-left: 3px solid var(--home-red); padding: 0.2rem 0 0.2rem 1.35rem; }
+  .home-boundary-note { border-left: 3px solid var(--home-ochre); padding: 0.2rem 0 0.2rem 1.35rem; }
   .home-boundary-note h3 { color: var(--home-ink); font-size: 1.35rem; line-height: 1.35; margin: 0.7rem 0; }
   .home-boundary-note p:not(.home-kicker) { color: var(--home-muted); line-height: 1.7; margin-bottom: 1.1rem; }
-  .home-team { background: #eef2ef; }
-  .home-team__grid { display: grid; gap: 4rem; grid-template-columns: minmax(220px, 0.55fr) minmax(0, 1.45fr); margin-top: 3.5rem; }
+  .home-team { background: var(--home-paper); }
+  .home-team__grid { display: grid; gap: 2.5rem; grid-template-columns: 1fr; margin-top: 3.5rem; }
+  .home-team__people { display: grid; gap: 4rem; grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr); }
   .home-team__people > p { color: var(--home-muted); line-height: 1.7; }
-  .home-team__people ul { border-top: 1px solid var(--home-rule); list-style: none; margin: 2rem 0 0; padding: 0; }
+  .home-team__people ul { border-top: 1px solid var(--home-rule); list-style: none; margin: 0; padding: 0; }
   .home-team__people li { border-bottom: 1px solid var(--home-rule); display: grid; gap: 0.22rem; padding: 0.8rem 0; }
   .home-team__people strong { color: var(--home-ink); font-size: 0.98rem; }
   .home-team__people span { color: var(--home-muted); font-size: 0.82rem; }
-  .home-team__photos { display: grid; gap: 0.8rem; grid-template-columns: 1.15fr 0.85fr; grid-template-rows: 1fr 1fr; min-height: 520px; }
+  .home-team__photos { display: grid; gap: 0.8rem; grid-template-columns: 1.5fr repeat(3, 1fr); grid-template-rows: 310px; min-height: 0; }
   .team-photo { margin: 0; min-height: 0; overflow: hidden; position: relative; }
-  .team-photo--1 { grid-row: span 2; }
+  .team-photo--1 { grid-row: auto; }
   .team-photo picture { display: block; height: 100%; }
   .team-photo img { display: block; height: 100%; object-fit: cover; transition: transform 360ms ease; width: 100%; }
   .team-photo:hover img { transform: scale(1.035); }
   .team-photo figcaption { background: linear-gradient(transparent, rgb(20 35 43 / 0.75)); bottom: 0; color: #fff; font-size: 0.76rem; left: 0; padding: 2rem 0.8rem 0.7rem; position: absolute; right: 0; }
+  .home-programs { background: #e8f0ed !important; }
   .home-program-list { border-top: 1px solid var(--home-rule); margin-top: 3.8rem; }
   .home-program { align-items: start; border-bottom: 1px solid var(--home-rule); display: grid; gap: 2rem; grid-template-columns: 4rem minmax(0, 1fr) auto; padding: 2rem 0; }
   .home-program__number { color: var(--home-muted); font-variant-numeric: tabular-nums; font-weight: 700; }
   .home-program__body { max-width: 680px; }
-  .home-program__body h3 { color: var(--home-ink); font-size: clamp(1.45rem, 2vw, 2rem); line-height: 1.15; margin: 0 0 0.6rem; }
+  .home-program__body h3 { color: var(--home-ink); font-size: 2rem; line-height: 1.15; margin: 0 0 0.6rem; }
   .home-program__body p { color: var(--home-muted); line-height: 1.68; margin: 0; }
   .home-program__evidence { border-left: 2px solid var(--home-blue); font-size: 0.83rem; margin-top: 0.9rem !important; padding-left: 0.8rem; }
   .home-program--lag .home-program__evidence { border-color: var(--home-red); }
@@ -345,15 +378,25 @@ const homeSchema = [
   .home-film p { color: #c9d5d3; font-size: 0.92rem; line-height: 1.62; }
   .home-film__scope { border-left: 2px solid #d0a95c; font-size: 0.8rem !important; padding-left: 0.7rem; }
   .home-publication-list { border-top: 1px solid var(--home-rule); margin-top: 3.6rem; }
-  .home-publication-list article { border-bottom: 1px solid var(--home-rule); display: grid; gap: 1rem; grid-template-columns: 4rem minmax(0, 1fr); padding: 1.25rem 0; }
-  .home-publication-list time { color: var(--home-blue); font-size: 0.9rem; font-weight: 750; }
-  .home-publication-list h3 { color: var(--home-ink); font-size: 1rem; line-height: 1.4; margin: 0 0 0.3rem; }
-  .home-publication-list p, .home-publication-list span { color: var(--home-muted); font-size: 0.82rem; line-height: 1.4; margin: 0; }
+  .home-publication-list article { align-items: center; border-bottom: 1px solid var(--home-rule); display: grid; gap: 4rem; grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.85fr); padding: 2.3rem 0; }
+  .home-publication-list__copy { display: grid; gap: 0.8rem; }
+  .home-publication-list__meta { align-items: center; display: flex; flex-wrap: wrap; gap: 0.8rem; }
+  .home-publication-list__meta span { border-left: 1px solid var(--home-rule); padding-left: 0.8rem; }
+  .home-publication-list time { color: var(--home-blue); font-size: 0.78rem; font-weight: 750; letter-spacing: 0.05em; }
+  .home-publication-list h3 { color: var(--home-ink); font-size: 1.8rem; line-height: 1.2; margin: 0; }
+  .home-publication-list p, .home-publication-list span { color: var(--home-muted); font-size: 0.88rem; line-height: 1.55; margin: 0; }
+  .home-publication-list__plain { font-size: 1rem !important; line-height: 1.7 !important; max-width: 680px; }
+  .home-publication-list__citation { font-size: 0.78rem !important; line-height: 1.55 !important; }
+  .home-publication-list__links { display: flex; flex-wrap: wrap; gap: 1rem; }
+  .home-publication-list__links a { color: var(--home-blue); font-size: 0.82rem; font-weight: 750; }
+  .home-publication-list__visual { margin: 0; min-width: 0; }
+  .home-publication-list__visual video { aspect-ratio: 16 / 9; background: #081116; display: block; height: auto; object-fit: cover; width: 100%; }
+  .home-publication-list__visual figcaption { color: var(--home-muted); font-size: 0.72rem; margin-top: 0.55rem; }
   .home-student-note { color: var(--home-muted); font-size: 0.84rem; margin-top: 1.25rem; }
-  .home-collaborate { background: #e5eee9; }
+  .home-collaborate { background: var(--home-ochre); }
   .home-collaborate__grid { align-items: end; display: grid; gap: 3rem; grid-template-columns: minmax(0, 1fr) minmax(280px, 0.7fr); }
-  .home-collaborate h2 { color: var(--home-ink); font-size: clamp(2.4rem, 4.5vw, 4.8rem); letter-spacing: 0; line-height: 0.98; }
-  .home-collaborate p { color: var(--home-muted); line-height: 1.7; margin-bottom: 1.5rem; }
+  .home-collaborate h2 { color: var(--home-ink); font-size: 4rem; letter-spacing: 0; line-height: 1; }
+  .home-collaborate p { color: var(--home-ink); line-height: 1.7; margin-bottom: 1.5rem; }
   .home-note-list { border-top: 1px solid var(--home-rule); margin-top: 3.5rem; }
   .home-note-list a { align-items: start; border-bottom: 1px solid var(--home-rule); display: grid; gap: 1.2rem; grid-template-columns: 7rem minmax(0, 1fr) auto; padding: 1.2rem 0; }
   .home-note-list a:hover strong, .home-note-list a:focus-visible strong { color: var(--home-blue); }
@@ -365,31 +408,35 @@ const homeSchema = [
   .home-concepts a:hover, .home-concepts a:focus-visible { border-color: var(--home-blue); color: var(--home-blue); }
   @media (max-width: 900px) {
     .home-shell { width: min(720px, calc(100% - 2rem)); }
-    .home-hero__grid, .home-proof__grid, .home-team__grid, .home-collaborate__grid { grid-template-columns: 1fr; }
-    .home-hero__copy { padding: 4rem 0 2.5rem; }
-    .home-hero__media { min-height: 420px; }
+    .home-proof__grid, .home-team__grid, .home-collaborate__grid, .home-publication-list article { grid-template-columns: 1fr; }
     .home-proof__grid, .home-team__grid { gap: 3rem; }
+    .home-team__people { gap: 2.5rem; grid-template-columns: 1fr; }
+    .home-team__photos { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: repeat(2, 250px); }
     .home-program { grid-template-columns: 3rem minmax(0, 1fr); }
     .home-program > .home-text-link { grid-column: 2; }
   }
   @media (max-width: 640px) {
     .home-section { padding: 5rem 0; }
     .home-section-heading--split { align-items: start; flex-direction: column; }
-    .home-hero h1 { font-size: clamp(2.8rem, 13vw, 4.5rem); }
-    .home-hero__media { min-height: 330px; }
     .home-proof__numbers { grid-template-columns: 1fr; }
     .home-proof__numbers div, .home-proof__numbers div + div { border-left: 0; padding: 1rem 0; }
     .home-proof__numbers div + div { border-top: 1px solid var(--home-rule); }
     .home-trajectory li { grid-template-columns: 1fr; }
-    .home-team__photos, .home-film-grid { grid-template-columns: 1fr; grid-template-rows: none; min-height: 0; }
+    .home-section-heading h2, .home-collaborate h2 { font-size: 2.45rem; }
+    .home-proof__numbers strong { font-size: 3.4rem; }
+    .home-team__photos { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-rows: repeat(2, 170px); min-height: 0; }
+    .home-film-grid { grid-template-columns: 1fr; grid-template-rows: none; min-height: 0; }
     .team-photo--1 { grid-row: auto; }
-    .team-photo { aspect-ratio: 4 / 3; }
+    .team-photo { aspect-ratio: auto; }
     .home-program { gap: 1rem; grid-template-columns: 2rem minmax(0, 1fr); }
     .home-program > .home-text-link { grid-column: 2; }
-    .home-publication-list article, .home-note-list a { grid-template-columns: 1fr; gap: 0.45rem; }
+    .home-publication-list article, .home-note-list a { grid-template-columns: 1fr; gap: 1.2rem; }
+    .home-publication-list h3 { font-size: 1.45rem; }
     .home-note-list a > span:last-child { display: none; }
   }
   @media (prefers-reduced-motion: reduce) {
     .home-button, .team-photo img { transition: none; }
+    .home-button:hover, .home-button:focus-visible { transform: none; }
+    .team-photo:hover img { transform: none; }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2311,6 +2311,18 @@ img {
   padding: 0.85rem;
 }
 
+.ldl-demo__equation summary {
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.ldl-demo__equation[open] summary {
+  margin-bottom: 0.2rem;
+}
+
 .tu-demo {
   border-top: 1px solid var(--line);
   display: grid;
@@ -5263,21 +5275,18 @@ body.stanford-group-site main {
   }
 
   .nav-links {
+    display: grid;
     flex: 1 0 100%;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    justify-content: start;
+    gap: 0.2rem 0;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     max-width: 100%;
     order: 2;
     overflow: visible;
+    width: 100%;
   }
 
   .brand {
     min-width: 0;
-  }
-
-  .nav-links > * {
-    flex: 0 0 auto;
   }
 
   .nav-links > [data-slot="button"] {
@@ -5286,7 +5295,9 @@ body.stanford-group-site main {
 
   .nav-links a {
     font-size: 0.78rem;
-    padding: 0.34rem 0.45rem;
+    justify-content: center;
+    padding: 0.34rem 0;
+    text-align: center;
   }
 
   .brand span {


### PR DESCRIPTION
## Summary
- rebuild the homepage around team activity, four research lines, research trajectory, and selected publication films
- add a full-bleed research hero and restrained GSAP progressive enhancement
- improve responsive layout, publication citation metadata, terminology, and WCAG contrast

## Verification
- `npm.cmd run build`
- responsive QA at 375, 768, 1280, and 1440 px with no horizontal overflow
- Lighthouse desktop/mobile: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100
- browser console: 0 errors