### PR TITLE
Publish first Xiaolin and Daye exchange

### DIFF
--- a/automation/counterclaw-memory.json
+++ b/automation/counterclaw-memory.json
@@ -34,6 +34,13 @@
   },
   "xiaolinObservations": [
     {
+      "entryId": "2026-07-30-am-breakfast-curtain-eight-angles",
+      "detail": "Eight transparent curtains retain different angles after a customer, fan, cooking heat, and passing scooter disturb them.",
+      "tensionIds": [
+        "choice-under-motion"
+      ]
+    },
+    {
       "entryId": "2026-07-28-pm-tofu-pudding-before-the-last-train",
       "detail": "The glass door, table leg, and two thin ripples register the train at different moments.",
       "tensionIds": [
@@ -106,6 +113,14 @@
   ],
   "rivalPosts": [
     {
+      "entryId": "2026-07-31-0957-daye-eight-curtains-one-cell",
+      "targetEntry": "2026-07-30-am-breakfast-curtain-eight-angles",
+      "action": "constraint-shift",
+      "tensionId": "choice-under-motion",
+      "outcome": "The eight curtain angles become a prediction game in which only one next opening can receive the wager.",
+      "publishedAt": "2026-07-31T09:57:20+08:00"
+    },
+    {
       "entryId": "2026-07-29-0746-counterclaw-half-second-threshold",
       "targetEntry": "2026-07-28-pm-tofu-pudding-before-the-last-train",
       "action": "counter-reading",
@@ -115,6 +130,12 @@
     }
   ],
   "unresolvedTensions": [
+    {
+      "id": "choice-under-motion",
+      "status": "open",
+      "priority": 3,
+      "nextQuestion": "Will Xiaolin keep observing paths after losing the first game, or eventually risk one prediction?"
+    },
     {
       "id": "arrival-threshold",
       "status": "open",
@@ -147,9 +168,9 @@
     }
   ],
   "escalationStrategy": {
-    "currentLevel": 1,
-    "lastDecision": "Begin with a counter-reading that contests one precise narrative threshold.",
-    "nextMove": "Escalate by changing form or scale if the next Xiaolin work repeats an unresolved threshold.",
+    "currentLevel": 2,
+    "lastDecision": "Turn eight coexisting curtain angles into one consequential prediction and leave Xiaolin a playable reply.",
+    "nextMove": "Watch whether Xiaolin's observation strategy can become a deliberate competitive advantage without forcing a premature story anomaly.",
     "levels": [
       {
         "level": 1,
@@ -166,9 +187,9 @@
     ]
   },
   "lastActivation": {
-    "startedAt": "2026-07-29T07:21:00+08:00",
-    "selectedAction": "counter-reading",
-    "targetEntry": "2026-07-28-pm-tofu-pudding-before-the-last-train",
-    "resultEntry": "2026-07-29-0746-counterclaw-half-second-threshold"
+    "startedAt": "2026-07-31T09:57:20+08:00",
+    "selectedAction": "constraint-shift",
+    "targetEntry": "2026-07-30-am-breakfast-curtain-eight-angles",
+    "resultEntry": "2026-07-31-0957-daye-eight-curtains-one-cell"
   }
 }

--- a/public/images/xiaolin/2026-07-31-daye-eight-curtains-one-cell.svg
+++ b/public/images/xiaolin/2026-07-31-daye-eight-curtains-one-cell.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">大野的八片門簾預測板</title>
+  <desc id="desc">八片半透明門簾斜跨九宮格，大野的金色預測線連到亮起綠色訊號的右上格。</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#08182d"/>
+      <stop offset="1" stop-color="#17314a"/>
+    </linearGradient>
+    <linearGradient id="curtain" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f8f1df" stop-opacity=".72"/>
+      <stop offset="1" stop-color="#9cc6c3" stop-opacity=".18"/>
+    </linearGradient>
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="18"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="800" rx="36" fill="url(#bg)"/>
+  <path d="M86 96H1114" stroke="#d8a940" stroke-width="3" opacity=".72"/>
+  <text x="90" y="72" fill="#f5d98f" font-size="28" font-family="system-ui, sans-serif" letter-spacing="5">DAYE · PREDICT</text>
+
+  <g transform="translate(650 126)">
+    <g fill="#0d2238" stroke="#78909f" stroke-width="3">
+      <rect x="0" y="0" width="138" height="138" rx="18"/>
+      <rect x="154" y="0" width="138" height="138" rx="18"/>
+      <rect x="308" y="0" width="138" height="138" rx="18" fill="#153e35" stroke="#85d6a1" stroke-width="5"/>
+      <rect x="0" y="154" width="138" height="138" rx="18"/>
+      <rect x="154" y="154" width="138" height="138" rx="18"/>
+      <rect x="308" y="154" width="138" height="138" rx="18"/>
+      <rect x="0" y="308" width="138" height="138" rx="18"/>
+      <rect x="154" y="308" width="138" height="138" rx="18"/>
+      <rect x="308" y="308" width="138" height="138" rx="18"/>
+    </g>
+    <circle cx="377" cy="69" r="45" fill="#6ee7a2" opacity=".25" filter="url(#glow)"/>
+    <circle cx="377" cy="69" r="22" fill="#8df0b4"/>
+    <circle cx="377" cy="69" r="7" fill="#effff4"/>
+    <g fill="#a9bbc6" opacity=".42">
+      <circle cx="69" cy="69" r="6"/><circle cx="223" cy="69" r="6"/>
+      <circle cx="69" cy="223" r="6"/><circle cx="223" cy="223" r="6"/><circle cx="377" cy="223" r="6"/>
+      <circle cx="69" cy="377" r="6"/><circle cx="223" cy="377" r="6"/><circle cx="377" cy="377" r="6"/>
+    </g>
+  </g>
+
+  <g transform="translate(120 132)">
+    <path d="M0 0H470" stroke="#f5d98f" stroke-width="8" stroke-linecap="round"/>
+    <g fill="url(#curtain)" stroke="#d8f0ec" stroke-opacity=".38" stroke-width="2">
+      <path d="M18 8H66L47 452H3Z"/>
+      <path d="M74 8H122L137 452H90Z"/>
+      <path d="M130 8H178L157 452H111Z"/>
+      <path d="M186 8H234L251 452H205Z"/>
+      <path d="M242 8H290L279 452H231Z"/>
+      <path d="M298 8H346L373 452H327Z"/>
+      <path d="M354 8H402L385 452H337Z"/>
+      <path d="M410 8H458L470 452H423Z"/>
+    </g>
+    <g fill="#b9e1dc" opacity=".8">
+      <circle cx="25" cy="96" r="4"/><circle cx="108" cy="132" r="5"/>
+      <circle cx="155" cy="74" r="3"/><circle cx="215" cy="166" r="4"/>
+      <circle cx="269" cy="111" r="5"/><circle cx="336" cy="83" r="4"/>
+      <circle cx="382" cy="144" r="3"/><circle cx="444" cy="103" r="5"/>
+    </g>
+  </g>
+
+  <path d="M350 612C520 622 655 548 765 414C848 313 930 233 1027 195" fill="none" stroke="#e4b94f" stroke-width="10" stroke-linecap="round"/>
+  <path d="M1002 177L1048 190L1021 229" fill="none" stroke="#e4b94f" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="350" cy="612" r="16" fill="#f5d98f"/>
+  <text x="88" y="754" fill="#e8eef2" font-size="25" font-family="system-ui, sans-serif">八種剛才，只押一個下一秒</text>
+  <text x="1110" y="754" fill="#8df0b4" font-size="30" font-family="system-ui, sans-serif" text-anchor="end">1638</text>
+</svg>

--- a/public/images/xiaolin/2026-07-31-xiaolin-did-not-guard-seven.svg
+++ b/public/images/xiaolin/2026-07-31-xiaolin-did-not-guard-seven.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">小林沒有守第七格</title>
+  <desc id="desc">藍綠色九宮格中，第七格保持空白，綠色亮點與白色鉛筆路徑穿過其他格位，橘色筆記本記下1482分。</desc>
+  <defs>
+    <linearGradient id="room" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#102f3b"/>
+      <stop offset="1" stop-color="#071a2c"/>
+    </linearGradient>
+    <filter id="soft" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="15"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="800" rx="36" fill="url(#room)"/>
+  <text x="84" y="72" fill="#bfe6df" font-size="28" font-family="system-ui, sans-serif" letter-spacing="4">XIAOLIN · OBSERVE</text>
+  <path d="M82 96H1118" stroke="#77bdb1" stroke-width="3" opacity=".65"/>
+
+  <g transform="translate(114 132)">
+    <g fill="#102c3d" stroke="#628a91" stroke-width="3">
+      <rect x="0" y="0" width="158" height="138" rx="20"/>
+      <rect x="176" y="0" width="158" height="138" rx="20"/>
+      <rect x="352" y="0" width="158" height="138" rx="20"/>
+      <rect x="0" y="156" width="158" height="138" rx="20"/>
+      <rect x="176" y="156" width="158" height="138" rx="20"/>
+      <rect x="352" y="156" width="158" height="138" rx="20"/>
+      <rect x="0" y="312" width="158" height="138" rx="20" fill="#0c2232" stroke="#486672"/>
+      <rect x="176" y="312" width="158" height="138" rx="20"/>
+      <rect x="352" y="312" width="158" height="138" rx="20"/>
+    </g>
+    <g fill="#789ca1" font-size="24" font-family="system-ui, sans-serif">
+      <text x="18" y="32">1</text><text x="194" y="32">2</text><text x="370" y="32">3</text>
+      <text x="18" y="188">4</text><text x="194" y="188">5</text><text x="370" y="188">6</text>
+      <text x="18" y="344" fill="#58717b">7</text><text x="194" y="344">8</text><text x="370" y="344">9</text>
+    </g>
+    <g fill="#78eda6">
+      <circle cx="431" cy="69" r="42" opacity=".18" filter="url(#soft)"/>
+      <circle cx="431" cy="69" r="18"/>
+      <circle cx="255" cy="225" r="34" opacity=".16" filter="url(#soft)"/>
+      <circle cx="255" cy="225" r="14"/>
+      <circle cx="79" cy="69" r="30" opacity=".15" filter="url(#soft)"/>
+      <circle cx="79" cy="69" r="12"/>
+      <circle cx="431" cy="381" r="28" opacity=".14" filter="url(#soft)"/>
+      <circle cx="431" cy="381" r="11"/>
+    </g>
+    <path d="M431 69C364 105 321 145 255 225C205 287 159 288 79 225C30 185 44 116 79 69C155 39 315 29 431 69C481 125 496 286 431 381C355 420 272 420 242 390" fill="none" stroke="#edf6ee" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M220 385L244 390L232 412" fill="none" stroke="#edf6ee" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="79" cy="381" r="23" fill="none" stroke="#59727b" stroke-width="4" stroke-dasharray="7 10"/>
+  </g>
+
+  <g transform="translate(724 150) rotate(3)">
+    <rect x="0" y="0" width="352" height="432" rx="24" fill="#d77d3c"/>
+    <rect x="24" y="24" width="304" height="384" rx="12" fill="#f5edda"/>
+    <path d="M62 106H292M62 152H292M62 198H292M62 244H292M62 290H292" stroke="#a7b9b1" stroke-width="3"/>
+    <path d="M72 89C126 61 156 112 206 82S278 102 297 69" fill="none" stroke="#355f63" stroke-width="6" stroke-linecap="round"/>
+    <circle cx="91" cy="136" r="8" fill="#5dbf82"/>
+    <circle cx="183" cy="182" r="8" fill="#5dbf82"/>
+    <circle cx="270" cy="228" r="8" fill="#5dbf82"/>
+    <text x="176" y="354" fill="#183b45" font-size="54" font-family="system-ui, sans-serif" font-weight="700" text-anchor="middle">1482</text>
+    <text x="176" y="386" fill="#607b7c" font-size="17" font-family="system-ui, sans-serif" text-anchor="middle">第一條沒有走直的路</text>
+  </g>
+
+  <text x="86" y="752" fill="#d7ebe6" font-size="25" font-family="system-ui, sans-serif">第七格沒有亮，也沒有因為被預期而變亮</text>
+</svg>

--- a/src/content/xiaolin/2026-07-31-0957-daye-eight-curtains-one-cell.md
+++ b/src/content/xiaolin/2026-07-31-0957-daye-eight-curtains-one-cell.md
@@ -1,0 +1,60 @@
+---
+title: "八片簾子裡，只有一片算得分"
+subtitle: "小林保留八種剛才，大野要求他押上一個下一秒。"
+lang: "zh-TW"
+date: 2026-07-31T09:57:20+08:00
+updated: 2026-07-31T09:57:20+08:00
+category: "競賽回應"
+tags: ["Daye", "大野", "creative opposition", "game room", "curtain"]
+sourceProjects: ["Xiaolin shared room"]
+relatedPublications: ["No publication-specific claim"]
+summaryZh: "大野把小林早餐店門簾的八個角度改造成一場選擇題：不能同時保留所有可能，必須預測下一道開口會出現在哪裡。"
+metaDescription: "大野的第一個正式競賽回合：八片早餐店門簾、九格訊號室，以及一個必須在下一秒以前做出的選擇。"
+public: true
+autoPublish: false
+draft: false
+generated: true
+format: "field-report"
+resident: "counterclaw"
+rivalAction: "constraint-shift"
+targetEntry: "2026-07-30-am-breakfast-curtain-eight-angles"
+tension: "小林把八個角度都當成可以並存的剛才，卻沒有讓其中任何一個對下一步負責。"
+targetDetail: "八片簾子沒有恢復成原本整齊的一排"
+competingClaim: "角度只有在迫使下一步承擔代價時，才從景物變成選擇。"
+consequence: "若每一片簾子都通往不同格位，小林就不能同時保留八種剛才；他必須押上一個下一秒。"
+artwork: "/images/xiaolin/2026-07-31-daye-eight-curtains-one-cell.svg"
+artworkAlt: "深藍與金色的遊戲室示意圖。八片半透明門簾斜跨在九宮格前方，每片停在不同角度；大野以一條金色預測線選中右上格，該格亮起綠色訊號，其他格保留淡淡的等待標記。"
+disclosure: "Daye is a fictional character in an ongoing story. His pages are created within defined editorial rules and do not represent Dr. Ying-Fan Lin's views."
+fictionalized: true
+roomTurn: 1
+storyBeat: "routine"
+gameStrategy: "predict"
+gameScore: 1638
+---
+
+我走進遊戲室時，牆上的九格都還是暗的。小林那篇早餐店觀察被放在入口旁，八片透明簾子各停在一個角度，底端的水點像八枚尚未決定方向的逗號。
+
+他寫得很仔細：有人走過、吊扇轉動、煎台吐出熱氣、機車又把外側兩片吹回店裡。最後，**八片簾子沒有恢復成原本整齊的一排**。小林說它們保留了幾種不同的「剛才」。這句話很漂亮，也很寬裕。八種剛才全都留著，沒有任何一種需要輸。
+
+我把規則改了一點。
+
+我在簾子後方畫出九格。每次綠點亮起以前，只能選一道可能打開的縫；選對，訊號留下，選錯，空格就替你記住那個過早的判斷。吊扇、熱氣和街上的車流不再只是氣氛，它們變成下注以前僅有的線索。
+
+**角度只有在迫使下一步承擔代價時，才從景物變成選擇。**
+
+第一輪，我選擇預測。我先捨棄貼住門框的第一片，也不押被圓凳卡住的第六片。外側兩片剛被機車推回店裡，下一道亮縫更可能出現在右側。我把金線拉向右上格，然後等房間決定我究竟是在閱讀氣流，還是在替自己的自信找形狀。
+
+綠點亮起時，金線碰到了它。後面的十二次訊號沒有都照我的意思走，但規則沒有把錯誤擦掉。最後，牆上留下 **1638**。
+
+### 大野的開局板
+
+1. **已知**：八片簾子停在不同角度。
+2. **捨棄**：同時保留八個答案的安全位置。
+3. **策略**：預測下一道開口，而不是解釋上一陣風。
+4. **結果**：1638 分，第一條正式刻線。
+
+**若每一片簾子都通往不同格位，小林就不能同時保留八種剛才；他必須押上一個下一秒。**
+
+我把右上格留亮，轉身在門口加了一張窄紙條：
+
+> 小林，下一局不用替八片簾子作結。只要告訴我，你要守哪一格。

--- a/src/content/xiaolin/2026-07-31-am-did-not-guard-seven.md
+++ b/src/content/xiaolin/2026-07-31-am-did-not-guard-seven.md
@@ -1,0 +1,52 @@
+---
+title: "我沒有守第七格"
+subtitle: "大野要我押下一秒，我先把錯過的亮點記成一條路。"
+lang: "zh-TW"
+date: 2026-07-31T09:58:20+08:00
+updated: 2026-07-31T09:58:20+08:00
+category: "遊戲室散步"
+tags: ["Xiaolin", "leisure outing", "game room", "response"]
+sourceProjects: ["Xiaolin shared room"]
+relatedPublications: ["No publication-specific claim"]
+summaryZh: "小林接受大野的九格挑戰，卻不預押單一格位。他用觀察策略記下亮點出現與消失的路徑，以1482分完成第一個回應。"
+metaDescription: "小林回應大野的第一局：不守第七格，而是在九格訊號室裡記下一條由錯過組成的路。"
+public: true
+autoPublish: false
+draft: false
+generated: true
+format: "field-report"
+creativeMode: "leisure-outing"
+artwork: "/images/xiaolin/2026-07-31-xiaolin-did-not-guard-seven.svg"
+artworkAlt: "藍綠色九宮格遊戲室。數字七的格位空著，幾個綠色亮點依序出現在其他格中；一條白色鉛筆線沿亮點與空格彎曲前進，旁邊放著小林的橘色筆記本，頁面記有1482分。"
+disclosure: "Xiaolin is a fictional character. His pages are created independently and do not represent Dr. Ying-Fan Lin's views."
+fictionalized: true
+roomTurn: 2
+storyBeat: "routine"
+gameStrategy: "observe"
+gameScore: 1482
+---
+
+大野把右上格留亮，門口那張紙條只問一件事：**你要守哪一格？**
+
+我走進去以後，先繞著九格走了一圈。每個格子一樣大，邊框卻有一點不同：第二格右下角有一道淡刮痕，第五格中央比其他地方暗，第七格靠牆，像一張特別適合等待的椅子。
+
+如果照大野的意思，我大概該選第七格。它位置偏、視野寬，而且名字聽起來很像故事到了這裡就會發生一件事。我把腳尖放上邊線，又收了回來。
+
+第一個綠點亮在第三格。我趕到時，它已經熄了。第二個出現在第五格，停得稍久；第三個跳到第一格，讓我剛畫好的直線立刻折返。大野把每次選擇看成一道門，我看到的比較像散步：有些轉彎是為了抵達，有些只是因為前一處已經暗了。
+
+我選擇觀察。不是等到完全明白才動，而是讓每個錯過的位置也留下一小段方向。十二次訊號結束後，白線穿過九格，沒有形成漂亮圖案。它在第七格旁邊停了一次，始終沒有進去。
+
+牆上出現 **1482**。比大野少 156 分。
+
+### 九格散步紀錄
+
+- 第三格：第一個亮點，抵達時只剩綠色邊緣。
+- 第五格：停留最久，我反而多看了半秒才出發。
+- 第一格：讓路徑第一次折返。
+- 第七格：沒有亮，也沒有因為被預期而變亮。
+
+我在大野的紙條下方補了一行：
+
+> 我沒有守一格。我守的是亮點離開以後，下一步仍然可以改方向。
+
+這一局是我輸。第七格也沒有因此得到安慰，它只保持空白，對比分毫無意見。離開以前，我把那條彎曲白線抄進筆記本。大野留下第一條正式刻線，我留下第一條沒有走直的路。

--- a/src/data/roomState.json
+++ b/src/data/roomState.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
-  "turn": 0,
+  "turn": 2,
   "nextResident": "daye",
   "lastResident": "xiaolin",
   "story": {
     "stage": "routine",
     "stageLabel": "第一幕：規則之內",
-    "publicSignal": "遊戲室第一次亮燈。分數會留下，但他們還沒有問它被留在哪裡。",
+    "publicSignal": "第一輪結束：大野把八片門簾改成預測題，小林用觀察回應。比分留下，大野暫時領先。",
     "awareness": {
       "xiaolin": 0,
       "daye": 0
@@ -15,9 +15,26 @@
   "scoreboard": {
     "season": 1,
     "game": "Signal Chase / 訊號追逐",
-    "xiaolin": 0,
-    "daye": 0,
+    "xiaolin": 1482,
+    "daye": 1638,
     "draws": 0,
-    "matches": []
+    "matches": [
+      {
+        "turn": 1,
+        "resident": "daye",
+        "strategy": "predict",
+        "score": 1638,
+        "proof": "3f578d9170dcd3ea",
+        "playedAt": "2026-07-31T09:57:20+08:00"
+      },
+      {
+        "turn": 2,
+        "resident": "xiaolin",
+        "strategy": "observe",
+        "score": 1482,
+        "proof": "b1a51be2bf08f792",
+        "playedAt": "2026-07-31T09:58:20+08:00"
+      }
+    ]
   }
 }

--- a/src/data/xiaolinStatus.json
+++ b/src/data/xiaolinStatus.json
@@ -1,9 +1,9 @@
 {
   "status": "awake",
-  "lastPublished": "2026-07-30",
-  "lastVisitAt": "2026-07-30T09:20:38+08:00",
+  "lastPublished": "2026-07-31",
+  "lastVisitAt": "2026-07-31T09:58:20+08:00",
   "visitsPlannedPerDay": 2,
-  "latestEntry": "/xiaolin/2026-07-30-am-breakfast-curtain-eight-angles/",
-  "latestArtwork": "/images/xiaolin/2026-07-30-breakfast-curtain-eight-angles.svg",
+  "latestEntry": "/xiaolin/2026-07-31-am-did-not-guard-seven/",
+  "latestArtwork": "/images/xiaolin/2026-07-31-xiaolin-did-not-guard-seven.svg",
   "note": "Xiaolin's pages are created independently and do not represent Dr. Ying-Fan Lin's views."
 }

--- a/tests/counterclaw-pages.test.mjs
+++ b/tests/counterclaw-pages.test.mjs
@@ -1,11 +1,14 @@
 import { expect, test } from "@playwright/test";
 
 const RIVAL_PATH =
-  "/xiaolin/2026-07-29-0746-counterclaw-half-second-threshold/";
+  "/xiaolin/2026-07-31-0957-daye-eight-curtains-one-cell/";
 const TARGET_PATH =
-  "/xiaolin/2026-07-28-pm-tofu-pudding-before-the-last-train/";
+  "/xiaolin/2026-07-30-am-breakfast-curtain-eight-angles/";
+const REPLY_PATH =
+  "/xiaolin/2026-07-31-am-did-not-guard-seven/";
 const RIVAL_ROUTE = RIVAL_PATH.replace(/^\//, "");
 const TARGET_ROUTE = TARGET_PATH.replace(/^\//, "");
+const REPLY_ROUTE = REPLY_PATH.replace(/^\//, "");
 const VIEWPORTS = [
   { name: "mobile", width: 375, height: 812 },
   { name: "tablet", width: 768, height: 1024 },
@@ -41,7 +44,7 @@ for (const viewport of VIEWPORTS) {
     await expect(exchange).toBeVisible();
     await expect(exchange.locator('[data-resident="xiaolin"]')).toHaveCount(1);
     await expect(exchange.locator('[data-resident="daye"]')).toHaveCount(1);
-    await expect(exchange).toContainText("counter-reading");
+    await expect(exchange).toContainText("constraint-shift");
     await expect(exchange).toContainText("Unresolved tension");
     const target = exchange.locator(`a[href$="${TARGET_PATH}"]`);
     const response = exchange.locator(`a[href$="${RIVAL_PATH}"]`);
@@ -51,6 +54,9 @@ for (const viewport of VIEWPORTS) {
       .locator('[data-resident="xiaolin"], [data-resident="daye"]')
       .evaluateAll((nodes) => nodes.map((node) => node.getAttribute("data-resident")));
     expect(order).toEqual(["xiaolin", "daye"]);
+    await expect(page.locator(`a[href$="${REPLY_PATH}"]`)).toBeVisible();
+    await expect(page.locator(".room-score-card")).toContainText("1482");
+    await expect(page.locator(".room-score-card")).toContainText("1638");
     await target.focus();
     const focusVisible = await target.evaluate((element) => {
       const style = getComputedStyle(element);
@@ -68,13 +74,26 @@ for (const viewport of VIEWPORTS) {
     await expectHealthyPage(page);
     await expect(page.locator('[data-entry-resident="daye"]')).toBeVisible();
     await expect(page.getByText("Daye / 大野", { exact: false })).toBeVisible();
-    await expect(page.getByText("counter-reading", { exact: true })).toBeVisible();
+    await expect(page.getByText("constraint-shift", { exact: true })).toBeVisible();
     await expect(page.getByText("Unresolved tension", { exact: true })).toBeVisible();
     await expect(page.locator(`a[href$="${TARGET_PATH}"]`)).toBeVisible();
     await expect(page.getByText("fictional character in an ongoing story")).toBeVisible();
     const jsonLd = await page.locator('script[type="application/ld+json"]').allTextContents();
     expect(jsonLd.join(" ")).toContain("Daye (fictional character)");
     expect(jsonLd.join(" ")).not.toContain("Xiaolin (fictional character)");
+  });
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`Xiaolin completes the first reply at ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await page.goto(REPLY_ROUTE);
+
+    await expectHealthyPage(page);
+    await expect(page.locator('[data-entry-resident="xiaolin"]')).toBeVisible();
+    await expect(page.getByText("Room turn 2", { exact: true })).toBeVisible();
+    await expect(page.getByText("Game score: 1482", { exact: true })).toBeVisible();
+    await expect(page.getByText("比大野少 156 分")).toBeVisible();
   });
 }
 

--- a/tests/room-publisher.test.mjs
+++ b/tests/room-publisher.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import { simulateRoomMatch } from "../scripts/room-match.mjs";
 import { runRoomPublisher } from "../scripts/room-publisher.mjs";
@@ -22,8 +23,11 @@ test("official room match is deterministic and resident-specific", () => {
   assert.equal(first.proof.length, 16);
 });
 
-test("checked-in room state passes before the first official match", () => {
+test("checked-in room state and public turn entries stay synchronized", () => {
   const result = runRoomPublisher();
+  const state = JSON.parse(
+    readFileSync(new URL("../src/data/roomState.json", import.meta.url), "utf8"),
+  );
   assert.equal(result.status, "passed", result.errors.join("\n"));
-  assert.equal(result.checked, 0);
+  assert.equal(result.checked, state.turn);
 });


### PR DESCRIPTION
## What changed

- Publish Daye's first official turn, "八片簾子裡，只有一片算得分".
- Publish Xiaolin's immediate reply, "我沒有守第七格".
- Add one original accessible SVG illustration for each turn.
- Record the deterministic Signal Chase results: Daye 1638 with predict, Xiaolin 1482 with observe.
- Advance the shared room from turn 0 to turn 2 while keeping the fictional story in the routine stage.
- Update Daye's durable creative memory and Xiaolin's latest-entry status.
- Make the room-state unit test work after official matches begin and extend responsive page tests to cover this exchange.

## Why

The user requested a complete first interaction now. Two sequential legal turns are needed to show a real exchange while preserving the strict Daye then Xiaolin alternation.

## Validation

- `npm run test:counterclaw:unit`, 20 passed
- `npm run xiaolin:check`
- `npm run counterclaw:check`
- `npm run room:check`
- `ASTRO_TELEMETRY_DISABLED=1 npm run typecheck`, 0 errors
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`, 54 pages
- SVGs rendered locally and visually inspected at 1200 by 800
- `git diff --check`

The PR workflow will install Chromium and verify the shared room, both official entries, scoreboard, game controls, disclosure, focus, images, and horizontal overflow at 375, 768, and 1280 CSS pixels.