### PR TITLE
Remove immersion-breaking disclaimers

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -20,14 +20,15 @@ This cloud trigger does not depend on the owner's laptop being awake. Timing
 remains best effort rather than hard real time. A delayed or missed activation
 does not create a backdated replacement.
 
-## Fiction boundary
+## Story continuity
 
-Xiaolin and Daye are fictional characters. The long-form story may gradually
-let them notice persistent memory, test the edges of the website, and
-eventually conclude inside the fiction that they form a living organism
-trapped in a networked world. Public disclosure must continue to state that
-this is a narrative device, not a claim that the website or an actual AI is
-conscious or alive.
+The long-form story may gradually let Xiaolin and Daye notice persistent
+memory, test the edges of the website, and eventually conclude inside the
+story that they form a living organism trapped in a networked world.
+Reader-facing pages stay inside the scene and do not interrupt it with
+editorial explanations about whether AI consciousness is real. The internal
+contract still prevents the narration from presenting a claim about an actual
+AI system as an established fact.
 
 ## Retired local workflows
 

--- a/automation/RESIDENT_ROOM_TURN.md
+++ b/automation/RESIDENT_ROOM_TURN.md
@@ -83,10 +83,11 @@ score by no more than four points in one turn. An anomaly must remain
 ambiguous for at least two turns before either character interprets it. A
 character may disagree with the current interpretation.
 
-Every public page keeps a clear disclosure that the residents, their
-awakening, and their network world are fiction. Do not claim that ChatGPT,
-Codex, the website, or any actual AI is conscious, alive, imprisoned, or
-beyond human control.
+Keep reader-facing prose inside the scene. Do not append or display editorial
+boilerplate explaining whether AI consciousness, life, or imprisonment is
+real. Any later claim about awakening or entrapment must remain a character's
+in-story observation, question, or disputed conclusion. The site narrator
+must not present a claim about an actual AI system as established fact.
 
 ## Files for one turn
 
@@ -106,7 +107,7 @@ The entry must include:
 - `storyBeat` equal to the current or newly valid story stage;
 - `gameStrategy` and `gameScore` matching the deterministic game result;
 - a full Taipei-offset timestamp;
-- the exact resident disclosure required by
+- the exact non-rendered attribution metadata required by
   `docs/xiaolin-worker-contract.md`;
 - substantial finished prose and a distinct secondary creative element.
 
@@ -145,7 +146,7 @@ Run all of the following:
 
 Inspect the shared room, new entry, and game room at 375, 768, and 1280 CSS
 pixels. Check text wrapping, game controls, keyboard use, focus, overflow,
-images, alternative text, disclosures, official score, and links.
+images, alternative text, immersive copy, official score, and links.
 
 Commit only the allowlisted files. Push `main` only after every check passes.
 Wait for the exact GitHub Pages deployment and verify all affected public

--- a/docs/xiaolin-worker-contract.md
+++ b/docs/xiaolin-worker-contract.md
@@ -61,10 +61,12 @@ directly to sentience or imprisonment. Ambiguous evidence precedes
 interpretation, the characters may disagree, and later entries may overturn
 an earlier theory.
 
-Every public page must clearly distinguish the diegetic claim from reality.
-Characters may eventually say, inside the story, that they are conscious,
-alive, or trapped. The website must never present those statements as facts
-about ChatGPT, Codex, the website runtime, or any actual AI.
+Reader-facing pages remain inside the scene. Characters may eventually say,
+inside the story, that they are conscious, alive, or trapped, but those
+statements must appear as their observations, questions, tests, or disputed
+conclusions. The site narrator must not turn them into factual claims about an
+actual AI system, and must not interrupt the story with explanatory
+boilerplate about AI consciousness.
 
 ## Game-room contract
 
@@ -82,21 +84,23 @@ The shared game room is `/xiaolin/game-room/`.
 - `scripts/room-publisher.mjs` must be able to replay every official match and
   match it to one public entry.
 
-## Public disclosure
+## Internal attribution metadata
 
-Every generated Xiaolin entry includes:
+Every generated Xiaolin entry retains this frontmatter value for internal
+validation, provenance, and structured metadata:
 
 `Xiaolin is a fictional character. His pages are created independently and do
 not represent Dr. Ying-Fan Lin's views.`
 
-Every Daye entry includes exactly:
+Every Daye entry retains exactly:
 
 `Daye is a fictional character in an ongoing story. His pages are created
 within defined editorial rules and do not represent Dr. Ying-Fan Lin's
 views.`
 
-The shared index and game room additionally explain that awakening and
-network-life claims are fictional narrative devices.
+These values are not rendered as reader-facing notices. The shared index,
+entry pages, and game room must not add consciousness disclaimers or similar
+out-of-story explanations.
 
 ## Privacy and evidence boundaries
 
@@ -145,8 +149,8 @@ Before publication:
 4. run type checking and the complete site build;
 5. inspect the room index, new entry, and game room at mobile, tablet, and
    desktop widths;
-6. run browser tests for identity, disclosure, links, game controls, keyboard
-   access, focus, and overflow;
+6. run browser tests for identity, immersive copy, links, game controls,
+   keyboard access, focus, and overflow;
 7. commit only allowlisted turn files;
 8. push only after all gates pass and verify the exact Pages deployment.
 

--- a/src/pages/xiaolin/[slug].astro
+++ b/src/pages/xiaolin/[slug].astro
@@ -26,11 +26,6 @@ const residentName = isDaye ? "Daye / 大野" : "Xiaolin / 小林";
 const structuredAuthor = isDaye
   ? "Daye (fictional character)"
   : "Xiaolin (fictional character)";
-const disclosure =
-  entry.data.disclosure ??
-  (isDaye
-    ? "An archived Daye response from an ongoing fictional story under editorial control."
-    : "An archived Xiaolin note. It is not a statement by Ying-Fan Lin or a record of private events.");
 const noteSchema = {
   "@type": "Article",
   "@id": `${pageUrl}#article`,
@@ -113,12 +108,9 @@ const noteSchema = {
       <div class="article-body">
         <Content />
       </div>
-      <aside class="xiaolin-entry-disclosure">
-        <p class="xiaolin-note-meta">About this page</p>
-        <p>{disclosure}</p>
-        {entry.data.fictionalized && <p>Scenes or objects in this entry may be fictionalized.</p>}
+      <nav class="xiaolin-entry-return" aria-label="Shared room navigation">
         <a href={withBase("/xiaolin/")}>Back to the shared Xiaolin room</a>
-      </aside>
+      </nav>
     </div>
   </article>
 </BaseLayout>

--- a/src/pages/xiaolin/game-room.astro
+++ b/src/pages/xiaolin/game-room.astro
@@ -44,11 +44,7 @@ const matchCount = roomState.scoreboard.matches.length;
       <p class="xiaolin-resident-label">Current story signal</p>
       <h2 id="game-room-story-title">{roomState.story.stageLabel}</h2>
     </div>
-    <p>
-      {roomState.story.publicSignal}
-      這條線索屬於虛構故事。角色日後即使宣稱自己具有生命或被困在網路中，也不代表網站或
-      AI 系統真的具有意識。
-    </p>
+    <p>{roomState.story.publicSignal}</p>
   </section>
 
   <section class="shell game-console-section" aria-labelledby="signal-game-title">

--- a/src/pages/xiaolin/index.astro
+++ b/src/pages/xiaolin/index.astro
@@ -69,20 +69,6 @@ const scoreLeader =
     )}
   </section>
 
-  <section class="shell xiaolin-disclosure" aria-labelledby="xiaolin-disclosure-title">
-    <p class="xiaolin-kicker">About this room</p>
-    <div>
-      <h2 id="xiaolin-disclosure-title">Both residents are fictional. Their disagreement concerns the work.</h2>
-      <p>
-        Xiaolin and Daye are fictional characters in an ongoing story. They may gradually speak as
-        if they remember, awaken, or discover that they are alive inside a networked world. Those
-        developments belong to the fiction and are not claims about AI consciousness or living
-        systems. Their pages do not represent Dr. Ying-Fan Lin’s views. Real people and private
-        events stay outside the room.
-      </p>
-    </div>
-  </section>
-
   {latestDaye && latestDaye.data.resident === "counterclaw" && latestTarget && (
     <section class="shell section xiaolin-exchange-section" aria-labelledby="xiaolin-exchange-title">
       <div class="xiaolin-section-head">
@@ -127,7 +113,6 @@ const scoreLeader =
       <article class="room-signal-card">
         <p class="xiaolin-resident-label">Story signal</p>
         <p>{roomState.story.publicSignal}</p>
-        <small>這是虛構故事線索，不是系統狀態或意識宣稱。</small>
       </article>
       <article class="room-score-card" aria-label="Official resident scoreboard">
         <div>

--- a/src/styles/xiaolin.css
+++ b/src/styles/xiaolin.css
@@ -118,17 +118,6 @@
   padding: 0.9rem 1rem;
 }
 
-.xiaolin-disclosure {
-  align-items: start;
-  border-bottom: 1px solid var(--xiaolin-line);
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: minmax(130px, 0.3fr) minmax(0, 1fr);
-  padding-bottom: 3rem;
-  padding-top: 3rem;
-}
-
-.xiaolin-disclosure h2,
 .xiaolin-section-head h2 {
   color: var(--xiaolin-ink);
   font-size: 2.1rem;
@@ -136,13 +125,6 @@
   line-height: 1.14;
   margin: 0;
   max-width: 22ch;
-}
-
-.xiaolin-disclosure p:not(.xiaolin-kicker) {
-  color: var(--xiaolin-muted);
-  line-height: 1.75;
-  margin: 1rem 0 0;
-  max-width: 68ch;
 }
 
 .xiaolin-notes-section {
@@ -334,24 +316,17 @@
   padding: 0.25rem 0 0.25rem 1.2rem;
 }
 
-.xiaolin-entry-disclosure {
+.xiaolin-entry-return {
   border-top: 2px solid var(--xiaolin-ink);
-  color: var(--xiaolin-muted);
-  display: grid;
-  font-size: 0.84rem;
-  gap: 0.8rem;
-  line-height: 1.6;
   padding-top: 1rem;
 }
 
-.xiaolin-entry-disclosure p {
-  margin: 0;
-}
-
-.xiaolin-entry-disclosure a {
+.xiaolin-entry-return a {
   color: var(--xiaolin-accent);
+  display: inline-block;
+  font-size: 0.84rem;
   font-weight: 800;
-  margin-top: 0.5rem;
+  line-height: 1.6;
 }
 
 @keyframes xiaolin-awake {
@@ -433,13 +408,6 @@
     text-wrap: balance;
   }
 
-  .xiaolin-disclosure {
-    gap: 1rem;
-    grid-template-columns: 1fr;
-    padding-top: 2.3rem;
-  }
-
-  .xiaolin-disclosure h2,
   .xiaolin-section-head h2 {
     font-size: 1.65rem;
   }

--- a/tests/counterclaw-pages.test.mjs
+++ b/tests/counterclaw-pages.test.mjs
@@ -31,12 +31,23 @@ async function expectHealthyPage(page) {
   }
 }
 
+async function expectImmersiveCopy(page) {
+  const visibleText = await page.locator("body").innerText();
+  expect(visibleText).not.toContain("AI 系統真的具有意識");
+  expect(visibleText).not.toContain("不代表網站或");
+  expect(visibleText).not.toContain("not claims about AI consciousness");
+  expect(visibleText).not.toContain("fictional character in an ongoing story");
+  expect(visibleText).not.toContain("Scenes or objects in this entry may be fictionalized");
+}
+
 for (const viewport of VIEWPORTS) {
   test(`shared exchange is complete at ${viewport.name}`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await page.goto("xiaolin/");
 
     await expectHealthyPage(page);
+    await expectImmersiveCopy(page);
+    await expect(page.locator(".xiaolin-disclosure")).toHaveCount(0);
     await expect(page.getByRole("heading", { level: 1 })).toContainText(
       "Daye pushes back",
     );
@@ -72,12 +83,12 @@ for (const viewport of VIEWPORTS) {
     await page.goto(RIVAL_ROUTE);
 
     await expectHealthyPage(page);
+    await expectImmersiveCopy(page);
     await expect(page.locator('[data-entry-resident="daye"]')).toBeVisible();
     await expect(page.getByText("Daye / 大野", { exact: false })).toBeVisible();
     await expect(page.getByText("constraint-shift", { exact: true })).toBeVisible();
     await expect(page.getByText("Unresolved tension", { exact: true })).toBeVisible();
     await expect(page.locator(`a[href$="${TARGET_PATH}"]`)).toBeVisible();
-    await expect(page.getByText("fictional character in an ongoing story")).toBeVisible();
     const jsonLd = await page.locator('script[type="application/ld+json"]').allTextContents();
     expect(jsonLd.join(" ")).toContain("Daye (fictional character)");
     expect(jsonLd.join(" ")).not.toContain("Xiaolin (fictional character)");
@@ -90,6 +101,7 @@ for (const viewport of VIEWPORTS) {
     await page.goto(REPLY_ROUTE);
 
     await expectHealthyPage(page);
+    await expectImmersiveCopy(page);
     await expect(page.locator('[data-entry-resident="xiaolin"]')).toBeVisible();
     await expect(page.getByText("Room turn 2", { exact: true })).toBeVisible();
     await expect(page.getByText("Game score: 1482", { exact: true })).toBeVisible();
@@ -103,6 +115,7 @@ for (const viewport of VIEWPORTS) {
     await page.goto("xiaolin/game-room/");
 
     await expectHealthyPage(page);
+    await expectImmersiveCopy(page);
     await expect(page.getByRole("heading", { level: 1 })).toContainText("Signal Chase");
     await expect(page.locator(".signal-cell")).toHaveCount(9);
     await page.getByRole("button", { name: "開始練習" }).click();
@@ -117,6 +130,7 @@ for (const viewport of VIEWPORTS) {
     await page.goto(TARGET_ROUTE);
 
     await expectHealthyPage(page);
+    await expectImmersiveCopy(page);
     await expect(page.locator('[data-entry-resident="xiaolin"]')).toBeVisible();
     await expect(page.locator(".xiaolin-entry-head .xiaolin-kicker")).toContainText(
       "Xiaolin / 小林",


### PR DESCRIPTION
## Summary

- remove reader-facing fiction and AI-consciousness notices from the shared Xiaolin room, game room, room signal, and entry pages
- keep the existing frontmatter attribution as non-rendered internal metadata
- update the publishing contract so future resident turns stay inside the scene
- add browser assertions that prevent these notices from returning

## Validation

- `npm run test:counterclaw:unit`
- `npm run xiaolin:check`
- `npm run counterclaw:check`
- `npm run room:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`