### PR TITLE
Fix SEO discovery and reduce homepage LCP delay

### DIFF
--- a/.github/visibility/visibility_report.mjs
+++ b/.github/visibility/visibility_report.mjs
@@ -70,6 +70,14 @@ function extractMetaDescription(html) {
   return match ? compactWhitespace(match[1]) : "";
 }
 
+function metaDescriptionDisplayUnits(value) {
+  const wideCharacter = /[\u1100-\u115f\u2e80-\ua4cf\uac00-\ud7a3\uf900-\ufaff\ufe10-\ufe6f\uff00-\uff60\uffe0-\uffe6]/;
+  return [...value].reduce(
+    (total, character) => total + (wideCharacter.test(character) ? 2 : 1),
+    0,
+  );
+}
+
 function hasCanonical(html) {
   return /<link\s+rel=["']canonical["']/i.test(html);
 }
@@ -142,6 +150,7 @@ function auditGeneratedSite(config) {
       title: "",
       description: "",
       descriptionLength: 0,
+      descriptionDisplayUnits: 0,
       hasCanonical: false,
       hasJsonLd: false,
       inSitemap: sitemapUrls.includes(expectedUrl)
@@ -156,6 +165,7 @@ function auditGeneratedSite(config) {
     audit.title = extractTitle(html);
     audit.description = extractMetaDescription(html);
     audit.descriptionLength = audit.description.length;
+    audit.descriptionDisplayUnits = metaDescriptionDisplayUnits(audit.description);
     audit.hasCanonical = hasCanonical(html);
     audit.hasJsonLd = hasJsonLd(html);
 
@@ -376,20 +386,20 @@ function buildRecommendations(config, audit, gsc, crossref, openAlex) {
 
   for (const page of audit.pageAudits) {
     if (!page.exists) continue;
-    if (page.descriptionLength > 0 && page.descriptionLength < thresholds.minimumMetaDescriptionCharacters) {
+    if (page.descriptionDisplayUnits > 0 && page.descriptionDisplayUnits < thresholds.minimumMetaDescriptionCharacters) {
       add(
         "P2",
         "metadata",
-        `${page.path} meta description is ${page.descriptionLength} characters.`,
+        `${page.path} meta description is ${page.descriptionDisplayUnits} display units (${page.descriptionLength} characters).`,
         "Expand the description with the page's decision value and canonical keyword.",
         "safe-automation"
       );
     }
-    if (page.descriptionLength > thresholds.maximumMetaDescriptionCharacters) {
+    if (page.descriptionDisplayUnits > thresholds.maximumMetaDescriptionCharacters) {
       add(
         "P2",
         "metadata",
-        `${page.path} meta description is ${page.descriptionLength} characters.`,
+        `${page.path} meta description is ${page.descriptionDisplayUnits} display units (${page.descriptionLength} characters).`,
         "Compress the description so search snippets do not truncate the core claim.",
         "safe-automation"
       );
@@ -559,7 +569,7 @@ function buildReport(config, audit, gsc, crossref, openAlex, recommendations) {
     "## 2. Technical SEO And AI-Search Readiness",
     "",
     markdownTable(
-      ["Page", "Exists", "In sitemap", "Meta chars", "Canonical", "JSON-LD", "Primary role"],
+      ["Page", "Exists", "In sitemap", "Meta chars", "Meta units", "Canonical", "JSON-LD", "Primary role"],
       audit.pageAudits.map((page) => {
         const target = config.targetPages.find((item) => normalizePath(item.path) === page.path);
         return [
@@ -567,6 +577,7 @@ function buildReport(config, audit, gsc, crossref, openAlex, recommendations) {
           page.exists ? "yes" : "no",
           page.inSitemap ? "yes" : "no",
           page.descriptionLength,
+          page.descriptionDisplayUnits,
           page.hasCanonical ? "yes" : "no",
           page.hasJsonLd ? "yes" : "no",
           target?.role ?? ""

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,6 +31,10 @@ jobs:
         run: npm ci
       - name: Build static site
         run: npm run build
+        env:
+          SITE_URL: https://aar246860.github.io
+          BASE_PATH: /yflin_web
+          PUBLIC_GA_MEASUREMENT_ID: G-0JHBH3R12D
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/scripts/tracking_gate.mjs
+++ b/scripts/tracking_gate.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 const root = process.cwd();
 const trackingHead = fs.readFileSync(path.join(root, "src/components/TrackingHead.astro"), "utf8");
+const deployWorkflow = fs.readFileSync(path.join(root, ".github/workflows/deploy-pages.yml"), "utf8");
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 
 const requiredSnippets = [
@@ -41,6 +42,10 @@ for (const check of requiredSnippets) {
 
 if (!packageJson.scripts?.["tracking:gate"]) {
   failures.push("package.json is missing `tracking:gate` script.");
+}
+
+if (!deployWorkflow.includes("PUBLIC_GA_MEASUREMENT_ID: G-0JHBH3R12D")) {
+  failures.push("GitHub Pages build is missing the public GA4 measurement ID.");
 }
 
 if (failures.length) {

--- a/scripts/visibility_report.mjs
+++ b/scripts/visibility_report.mjs
@@ -70,6 +70,14 @@ function extractMetaDescription(html) {
   return match ? compactWhitespace(match[1]) : "";
 }
 
+function metaDescriptionDisplayUnits(value) {
+  const wideCharacter = /[\u1100-\u115f\u2e80-\ua4cf\uac00-\ud7a3\uf900-\ufaff\ufe10-\ufe6f\uff00-\uff60\uffe0-\uffe6]/;
+  return [...value].reduce(
+    (total, character) => total + (wideCharacter.test(character) ? 2 : 1),
+    0,
+  );
+}
+
 function hasCanonical(html) {
   return /<link\s+rel=["']canonical["']/i.test(html);
 }
@@ -142,6 +150,7 @@ function auditGeneratedSite(config) {
       title: "",
       description: "",
       descriptionLength: 0,
+      descriptionDisplayUnits: 0,
       hasCanonical: false,
       hasJsonLd: false,
       inSitemap: sitemapUrls.includes(expectedUrl)
@@ -156,6 +165,7 @@ function auditGeneratedSite(config) {
     audit.title = extractTitle(html);
     audit.description = extractMetaDescription(html);
     audit.descriptionLength = audit.description.length;
+    audit.descriptionDisplayUnits = metaDescriptionDisplayUnits(audit.description);
     audit.hasCanonical = hasCanonical(html);
     audit.hasJsonLd = hasJsonLd(html);
 
@@ -376,20 +386,20 @@ function buildRecommendations(config, audit, gsc, crossref, openAlex) {
 
   for (const page of audit.pageAudits) {
     if (!page.exists) continue;
-    if (page.descriptionLength > 0 && page.descriptionLength < thresholds.minimumMetaDescriptionCharacters) {
+    if (page.descriptionDisplayUnits > 0 && page.descriptionDisplayUnits < thresholds.minimumMetaDescriptionCharacters) {
       add(
         "P2",
         "metadata",
-        `${page.path} meta description is ${page.descriptionLength} characters.`,
+        `${page.path} meta description is ${page.descriptionDisplayUnits} display units (${page.descriptionLength} characters).`,
         "Expand the description with the page's decision value and canonical keyword.",
         "safe-automation"
       );
     }
-    if (page.descriptionLength > thresholds.maximumMetaDescriptionCharacters) {
+    if (page.descriptionDisplayUnits > thresholds.maximumMetaDescriptionCharacters) {
       add(
         "P2",
         "metadata",
-        `${page.path} meta description is ${page.descriptionLength} characters.`,
+        `${page.path} meta description is ${page.descriptionDisplayUnits} display units (${page.descriptionLength} characters).`,
         "Compress the description so search snippets do not truncate the core claim.",
         "safe-automation"
       );
@@ -559,7 +569,7 @@ function buildReport(config, audit, gsc, crossref, openAlex, recommendations) {
     "## 2. Technical SEO And AI-Search Readiness",
     "",
     markdownTable(
-      ["Page", "Exists", "In sitemap", "Meta chars", "Canonical", "JSON-LD", "Primary role"],
+      ["Page", "Exists", "In sitemap", "Meta chars", "Meta units", "Canonical", "JSON-LD", "Primary role"],
       audit.pageAudits.map((page) => {
         const target = config.targetPages.find((item) => normalizePath(item.path) === page.path);
         return [
@@ -567,6 +577,7 @@ function buildReport(config, audit, gsc, crossref, openAlex, recommendations) {
           page.exists ? "yes" : "no",
           page.inSitemap ? "yes" : "no",
           page.descriptionLength,
+          page.descriptionDisplayUnits,
           page.hasCanonical ? "yes" : "no",
           page.hasJsonLd ? "yes" : "no",
           target?.role ?? ""

--- a/src/components/home/FeaturedResearchFilms.astro
+++ b/src/components/home/FeaturedResearchFilms.astro
@@ -23,7 +23,7 @@ const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
             controls
             playsinline
             preload="none"
-            poster={withBase("/videos/featured/aquifer-memory-modes.webp")}
+            data-deferred-poster={withBase("/videos/featured/aquifer-memory-modes.webp")}
             width="720"
             height="1280"
             aria-label="How many memories does an aquifer need research film"
@@ -59,7 +59,7 @@ const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
             controls
             playsinline
             preload="none"
-            poster={withBase("/videos/featured/why-lagging-theory.webp")}
+            data-deferred-poster={withBase("/videos/featured/why-lagging-theory.webp")}
             width="720"
             height="1280"
             aria-label="Why Lagging Theory? research film"
@@ -96,7 +96,7 @@ const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
             controls
             playsinline
             preload="none"
-            poster={withBase("/videos/featured/one-test-two-estimates.webp")}
+            data-deferred-poster={withBase("/videos/featured/one-test-two-estimates.webp")}
             width="720"
             height="1280"
             aria-label="One test, two storage estimates research film"
@@ -133,7 +133,7 @@ const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
             controls
             playsinline
             preload="none"
-            poster={withBase("/videos/featured/one-wave-two-answers.webp")}
+            data-deferred-poster={withBase("/videos/featured/one-wave-two-answers.webp")}
             width="720"
             height="1280"
             aria-label="One aquifer, two answers research film"
@@ -173,7 +173,7 @@ const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
             controls
             playsinline
             preload="none"
-            poster={withBase("/videos/featured/web-first-manuscript-workflow.webp")}
+            data-deferred-poster={withBase("/videos/featured/web-first-manuscript-workflow.webp")}
             width="720"
             height="1280"
             aria-label="Web-first manuscript workflow research film"

--- a/src/components/home/HomeResearchHero.astro
+++ b/src/components/home/HomeResearchHero.astro
@@ -11,7 +11,7 @@ const imageSrcset = (path: string, extension: "avif" | "webp") =>
 const heroImage = "/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg";
 ---
 
-<div class="home-hero-system" data-home-hero>
+<div class="home-hero-system">
 <section class="research-hero" aria-labelledby="home-title">
   <figure class="research-hero__media">
     <picture>
@@ -32,13 +32,13 @@ const heroImage = "/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg";
 
   <div class="home-shell research-hero__content">
     <div class="research-hero__copy">
-      <p class="research-hero__kicker" data-hero-reveal>Groundwater hydraulics · memory · decision</p>
-      <h1 id="home-title" data-hero-reveal>Groundwater responses leave traces in time.</h1>
-      <p class="research-hero__lede" data-hero-reveal>
+      <p class="research-hero__kicker">Groundwater hydraulics · memory · decision</p>
+      <h1 id="home-title">Groundwater responses leave traces in time.</h1>
+      <p class="research-hero__lede">
         We interpret aquifer tests, groundwater memory, and subsurface thermal systems for decisions that must
         withstand uncertainty.
       </p>
-      <div class="research-hero__actions" data-hero-reveal>
+      <div class="research-hero__actions">
         <a class="research-hero__button research-hero__button--solid" href={withBase("/projects/")}>
           Explore the research <span aria-hidden="true">→</span>
         </a>
@@ -46,7 +46,7 @@ const heroImage = "/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg";
           Discuss a collaboration
         </a>
       </div>
-      <p class="research-hero__note" data-hero-reveal>
+      <p class="research-hero__note">
         Led by Ying-Fan Lin · analytical well hydraulics · transformation uncertainty
       </p>
     </div>
@@ -56,7 +56,7 @@ const heroImage = "/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg";
 
 <section class="hydraulic-trace-band" aria-label="From pumping history to groundwater decision">
   <div class="home-shell hydraulic-trace-band__inner">
-    <aside class="hydraulic-trace" aria-labelledby="hydraulic-trace-title" data-hero-reveal>
+    <aside class="hydraulic-trace" aria-labelledby="hydraulic-trace-title">
       <div class="hydraulic-trace__heading">
         <div>
           <p>Conceptual pumping-test trace</p>
@@ -96,48 +96,3 @@ const heroImage = "/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg";
   </div>
 </section>
 </div>
-
-<script>
-  import { gsap } from "gsap";
-
-  let heroContext: gsap.Context | undefined;
-  let heroMedia: gsap.MatchMedia | undefined;
-
-  const clearHeroMotion = () => {
-    heroMedia?.revert();
-    heroContext?.revert();
-    heroMedia = undefined;
-    heroContext = undefined;
-  };
-
-  const mountHeroMotion = () => {
-    const hero = document.querySelector<HTMLElement>("[data-home-hero]");
-    if (!hero || hero.dataset.motionReady === "true") return;
-
-    clearHeroMotion();
-    hero.dataset.motionReady = "true";
-    heroContext = gsap.context(() => {
-      heroMedia = gsap.matchMedia();
-      heroMedia.add("(prefers-reduced-motion: no-preference)", () => {
-        const paths = Array.from(hero.querySelectorAll<SVGPathElement>("[data-trace-path]"));
-        paths.forEach((path) => {
-          const length = path.getTotalLength();
-          gsap.set(path, { strokeDasharray: length, strokeDashoffset: length });
-        });
-
-        const timeline = gsap.timeline({ defaults: { ease: "power2.out" } });
-        timeline
-          .from(".research-hero__image", { scale: 1.035, duration: 1.4, ease: "power1.out" })
-          .from("[data-hero-reveal]", { autoAlpha: 0, y: 16, duration: 0.62, stagger: 0.08 }, 0.08)
-          .to(paths, { strokeDashoffset: 0, duration: 0.75, stagger: 0.1, ease: "power1.inOut" }, 0.4)
-          .from(".hydraulic-trace__point", { autoAlpha: 0, scale: 0.5, duration: 0.32, stagger: 0.12 }, 0.95);
-
-        return () => timeline.kill();
-      });
-    }, hero);
-  };
-
-  mountHeroMotion();
-  document.addEventListener("astro:page-load", mountHeroMotion);
-  document.addEventListener("astro:before-swap", clearHeroMotion);
-</script>

--- a/src/components/home/PapersRereviewedFeature.astro
+++ b/src/components/home/PapersRereviewedFeature.astro
@@ -23,8 +23,8 @@ const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;
       <video
         controls
         playsinline
-        preload="metadata"
-        poster={withBase("/videos/re-reviewed/2019-ates/paper-roast-2019-ates-episode-03.jpg")}
+        preload="none"
+        data-deferred-poster={withBase("/videos/re-reviewed/2019-ates/paper-roast-2019-ates-episode-03.jpg")}
         width="1080"
         height="1920"
         aria-label="Reviewer number three revisits the 2019 aquifer thermal energy storage model"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -54,6 +54,10 @@ const pagePath = canonicalPath ?? routePath(Astro.url.pathname);
 const canonicalUrl = absoluteUrl(pagePath, Astro.site);
 const rootUrl = siteRoot(Astro.site);
 const imageUrl = image ? absoluteUrl(image, Astro.site) : undefined;
+const openGraphLocale = lang === "zh-Hant" ? "zh_TW" : "en_US";
+const alternateLanguage = lang === "en" ? "zh-Hant" : "en";
+const alternateLocale = lang === "en" ? "zh_TW" : "en_US";
+const alternateUrl = translatedPath ? absoluteUrl(translatedPath, Astro.site) : undefined;
 const jsonLd = {
   "@context": "https://schema.org",
   "@graph": [
@@ -73,14 +77,22 @@ const jsonLd = {
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <meta name="author" content={authorName} />
-    <meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow, max-snippet:-1, max-image-preview:large"} />
+    <meta name="robots" content={noindex ? "noindex, follow" : "index, follow, max-snippet:-1, max-image-preview:large"} />
     <link rel="canonical" href={canonicalUrl} />
-    {translatedPath && <link rel="alternate" hreflang={lang === "en" ? "zh-Hant" : "en"} href={absoluteUrl(translatedPath, Astro.site)} />}
+    {alternateUrl && (
+      <>
+        <link rel="alternate" hreflang={lang} href={canonicalUrl} />
+        <link rel="alternate" hreflang={alternateLanguage} href={alternateUrl} />
+        <link rel="alternate" hreflang="x-default" href={lang === "en" ? canonicalUrl : alternateUrl} />
+      </>
+    )}
     <link rel="icon" href={`${base}favicon.svg`} type="image/svg+xml" />
     <meta property="og:site_name" content={siteName} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />
-    <meta property="og:type" content={type === "article" ? "article" : "website"} />
+    <meta property="og:type" content={type} />
+    <meta property="og:locale" content={openGraphLocale} />
+    {alternateUrl && <meta property="og:locale:alternate" content={alternateLocale} />}
     <meta property="og:url" content={canonicalUrl} />
     {imageUrl && <meta property="og:image" content={imageUrl} />}
     <meta name="twitter:card" content={imageUrl ? "summary_large_image" : "summary"} />

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,12 +1,25 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ResearchLineage from "../../components/ResearchLineage.astro";
+import { absoluteUrl, siteRoot } from "../../lib/seo";
+
+const rootUrl = siteRoot(Astro.site);
+const profileUrl = absoluteUrl("/about/", Astro.site);
+const profileSchema = {
+  "@type": "ProfilePage",
+  "@id": `${profileUrl}#profile`,
+  url: profileUrl,
+  mainEntity: { "@id": `${rootUrl}/#person` },
+};
 ---
 
 <BaseLayout
   title="About Ying-Fan Lin"
-  description="Ying-Fan Lin studies groundwater records whose timing differs from conventional aquifer-test or thermal-response models."
+  description="Profile of Ying-Fan Lin, whose research connects analytical well hydraulics, groundwater memory, Lagging Theory, transformation uncertainty, and subsurface energy."
   current="about"
+  canonicalPath="/about/"
+  type="profile"
+  schema={profileSchema}
 >
   <section class="shell section">
     <span class="eyebrow">About the research program</span>

--- a/src/pages/collaborate/index.astro
+++ b/src/pages/collaborate/index.astro
@@ -13,7 +13,7 @@ const withBase = (path) => `${base}${path.replace(/^\//, "")}`;
 
 <BaseLayout
   title="Collaborate on Aquifer-Test and Thermal-Response Interpretation"
-  description="Collaboration routes for aquifer-test residuals, TRT interpretation, transformation uncertainty, and subsurface energy decisions."
+  description="Collaborate with Ying-Fan Lin on aquifer-test residuals, TRT interpretation, transformation uncertainty, and groundwater-informed subsurface energy decisions."
   current="collaborate"
 >
   <ResearchHero

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import publications from "../data/publications.generated.json";
 import { getPlainLanguage, getVisualStatus } from "../data/publicationPresentation";
 import { activityPhotos, studentPublicationIds } from "../data/groupSite";
 import { researchPrograms } from "../data/researchPrograms";
+import { canonicalAnswers } from "../data/canonicalAnswers";
 
 const concepts = (await getCollection("concepts", ({ data }) => !data.draft)).sort(
   (a, b) => a.data.order - b.data.order,
@@ -29,6 +30,7 @@ const selectedPublications = selectedPublicationIds
   .filter(Boolean);
 const publicRecords = publications.filter((publication) => ["published", "accepted"].includes(publication.status));
 const studentPublications = publications.filter((publication) => studentPublicationIds.includes(publication.id));
+const featuredAnswers = [canonicalAnswers[0], canonicalAnswers[1], canonicalAnswers[3]];
 const publicationMediaVersion = "20260721";
 const withMediaVersion = (path: string) => `${withBase(path)}?v=${publicationMediaVersion}`;
 const roleLabel: Record<string, string> = {
@@ -51,18 +53,23 @@ const homeSchema = [
     knowsAbout: researchPrograms.map((program) => program.title),
   },
   {
-    "@type": "WebSite",
-    "@id": `${homeUrl}#website`,
-    url: homeUrl,
-    name: "Lin Groundwater Hydraulics Group",
-    inLanguage: "en",
+    "@type": "DefinedTerm",
+    name: "Lagging Darcy Law",
+    description: canonicalAnswers[0].shortAnswer,
+    url: absoluteUrl(canonicalAnswers[0].evidencePage, Astro.site),
+  },
+  {
+    "@type": "DefinedTerm",
+    name: "Flux-gradient asynchrony",
+    description: canonicalAnswers[1].shortAnswer,
+    url: absoluteUrl(canonicalAnswers[1].evidencePage, Astro.site),
   },
 ];
 ---
 
 <BaseLayout
   title="Lin Groundwater Hydraulics Group"
-  description="Lin Groundwater Hydraulics Group studies analytical well hydraulics, Lagging Theory, transformation uncertainty, and groundwater-informed subsurface energy decisions."
+  description="Research by Ying-Fan Lin on analytical well hydraulics, Lagging Theory, aquifer-test interpretation, transformation uncertainty, and subsurface energy."
   current="home"
   canonicalPath="/"
   image="/media/team-life/jpgu-2026/jpgu-2026-team-selfie.jpg"
@@ -71,6 +78,31 @@ const homeSchema = [
   pageClass="research-home"
 >
   <HomeResearchHero />
+
+  <section class="home-section home-answers" aria-labelledby="home-answers-title">
+    <div class="home-shell">
+      <div class="home-section-heading">
+        <p class="home-kicker">Start with a research question</p>
+        <h2 id="home-answers-title">Three direct routes into the research programme.</h2>
+        <p>Each short answer links to the public evidence, interpretation scope, and stated boundary behind it.</p>
+      </div>
+      <div class="canonical-answer-blocks">
+        <div class="answer-grid">
+          {featuredAnswers.map((answer) => (
+            <article class="canonical-answer-card">
+              <h3>{answer.question}</h3>
+              <p>{answer.shortAnswer}</p>
+              <p class="muted"><strong>Boundary:</strong> {answer.avoid}</p>
+              <a class="home-text-link" href={withBase(answer.evidencePage)}>
+                Evidence and scope <span aria-hidden="true">→</span>
+              </a>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+
   <FeaturedResearchFilms />
   <PapersRereviewedFeature />
 
@@ -208,7 +240,7 @@ const homeSchema = [
                   <video
                     controls
                     preload="none"
-                    poster={withMediaVersion(visual.film.poster)}
+                    data-deferred-poster={withMediaVersion(visual.film.poster)}
                     width="1280"
                     height="720"
                     aria-label={`Visual explanation for ${publication.title.en}`}
@@ -274,16 +306,21 @@ const homeSchema = [
 </BaseLayout>
 
 <script>
-  import { gsap } from "gsap";
-
-  let homeRevealContext: gsap.Context | undefined;
   let homeRevealObserver: IntersectionObserver | undefined;
+  let homePosterObserver: IntersectionObserver | undefined;
 
   const clearHomeReveals = () => {
     homeRevealObserver?.disconnect();
-    homeRevealContext?.revert();
+    homePosterObserver?.disconnect();
     homeRevealObserver = undefined;
-    homeRevealContext = undefined;
+    homePosterObserver = undefined;
+  };
+
+  const loadDeferredPoster = (video: HTMLVideoElement) => {
+    const poster = video.dataset.deferredPoster;
+    if (!poster) return;
+    video.poster = poster;
+    delete video.dataset.deferredPoster;
   };
 
   const mountHomeReveals = () => {
@@ -292,22 +329,41 @@ const homeSchema = [
     page.dataset.revealsReady = "true";
 
     clearHomeReveals();
+
+    const videos = Array.from(page.querySelectorAll<HTMLVideoElement>("video[data-deferred-poster]"));
+    if (!("IntersectionObserver" in window)) {
+      videos.forEach(loadDeferredPoster);
+      return;
+    }
+    homePosterObserver = new IntersectionObserver((entries, observer) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        loadDeferredPoster(entry.target as HTMLVideoElement);
+        observer.unobserve(entry.target);
+      });
+    }, { rootMargin: "500px 0px", threshold: 0.01 });
+    videos.forEach((video) => homePosterObserver?.observe(video));
+
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
 
     const targets = Array.from(page.querySelectorAll<HTMLElement>(
       ".home-section-heading, .home-team__photos, .home-program, .home-proof__numbers, .home-proof__grid, .home-publication-list article, .home-collaborate__grid",
     ));
 
-    homeRevealContext = gsap.context(() => {
-      homeRevealObserver = new IntersectionObserver((entries, observer) => {
-        entries.forEach((entry) => {
-          if (!entry.isIntersecting) return;
-          gsap.from(entry.target, { autoAlpha: 0, y: 18, duration: 0.6, ease: "power2.out", clearProps: "transform,opacity,visibility" });
-          observer.unobserve(entry.target);
-        });
-      }, { rootMargin: "0px 0px -8%", threshold: 0.08 });
-      targets.forEach((target) => homeRevealObserver?.observe(target));
-    }, page);
+    homeRevealObserver = new IntersectionObserver((entries, observer) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        entry.target.animate(
+          [
+            { opacity: 0, transform: "translateY(18px)" },
+            { opacity: 1, transform: "translateY(0)" },
+          ],
+          { duration: 600, easing: "cubic-bezier(0.16, 1, 0.3, 1)" },
+        );
+        observer.unobserve(entry.target);
+      });
+    }, { rootMargin: "0px 0px -8%", threshold: 0.08 });
+    targets.forEach((target) => homeRevealObserver?.observe(target));
   };
 
   mountHomeReveals();

--- a/src/pages/publications/index.astro
+++ b/src/pages/publications/index.astro
@@ -16,7 +16,7 @@ const availableFilmCount = allPublications.filter((publication) => getVisualStat
 const retrospectivePublicationId = "2016-07-41";
 ---
 
-<BaseLayout title="Publications by Research Concept" description="Ying-Fan Lin publications on Lagging Theory, well hydraulics, transformation uncertainty, and subsurface energy interpretation." current="publications" pageClass="publications-archive">
+<BaseLayout title="Publications by Research Concept" description="Publications by Ying-Fan Lin on analytical well hydraulics, Lagging Theory, aquifer-test interpretation, transformation uncertainty, and subsurface energy." current="publications" pageClass="publications-archive">
   <section class="shell section publications-archive__intro">
     <span class="eyebrow">Publication map</span>
     <h1>The publication record traces how the questions and methods have developed.</h1>

--- a/src/pages/search/index.astro
+++ b/src/pages/search/index.astro
@@ -11,6 +11,8 @@ const pagefindPath = `${base}pagefind/pagefind.js`;
   title="Search"
   description="Static Pagefind search for the research website."
   current="search"
+  canonicalPath="/search/"
+  noindex={true}
 >
   <section class="shell section">
     <span class="eyebrow">Static search</span>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -3,10 +3,13 @@ import { publicationFeatures } from "../data/publicationFeatures";
 
 const staticPages = [
   "/",
+  "/projects/",
   "/concepts/",
   "/glossary/",
   "/decision-lab/",
+  "/explainers/",
   "/tools/",
+  "/training/",
   "/field-notes/",
   "/papers-re-reviewed/",
   "/publications/",
@@ -15,10 +18,20 @@ const staticPages = [
   "/services/groundwater-decision-reliability-audit/",
   "/about/",
   "/team/",
-  "/search/",
-  "/llms.txt",
-  "/llms-full.txt",
+  "/zh/",
+  "/games/wbwwb/",
+  "/xiaolin/",
+  "/xiaolin/game-room/",
+  "/xiaolin/journal/",
 ];
+
+type SitemapEntry = {
+  path: string;
+  updated?: Date;
+};
+
+const xmlEscape = (value: string) =>
+  value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 
 export async function GET({ site }) {
   const siteBase = site?.toString().replace(/\/$/, "") ?? "https://aar246860.github.io";
@@ -26,16 +39,39 @@ export async function GET({ site }) {
   const base = `${siteBase}${basePath}`;
   const concepts = await getCollection("concepts", ({ data }) => !data.draft);
   const notes = await getCollection("field-notes", ({ data }) => !data.draft);
-  const urls = [
-    ...staticPages,
-    ...concepts.map((entry) => `/concepts/${entry.id}/`),
-    ...notes.map((entry) => `/field-notes/${entry.id}/`),
-    ...publicationFeatures.map((entry) => `/publications/${entry.id}/`),
+  const xiaolinEntries = await getCollection(
+    "xiaolin",
+    ({ data }) => data.public && !data.draft,
+  );
+  const journalEntries = await getCollection(
+    "resident-journal",
+    ({ data }) => data.public && !data.draft,
+  );
+  const entries: SitemapEntry[] = [
+    ...staticPages.map((path) => ({ path })),
+    ...concepts.map((entry) => ({ path: `/concepts/${entry.id}/`, updated: entry.data.updated })),
+    ...notes.map((entry) => ({ path: `/field-notes/${entry.id}/`, updated: entry.data.updated })),
+    ...publicationFeatures.map((entry) => ({ path: `/publications/${entry.id}/` })),
+    ...xiaolinEntries.map((entry) => ({ path: `/xiaolin/${entry.id}/`, updated: entry.data.updated })),
+    ...journalEntries.map((entry) => ({
+      path: `/xiaolin/journal/${entry.id}/`,
+      updated: entry.data.updated,
+    })),
   ];
+  const uniqueEntries = [...new Map(entries.map((entry) => [entry.path, entry])).values()].sort(
+    (a, b) => a.path.localeCompare(b.path),
+  );
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map((url) => `  <url><loc>${base}${url}</loc></url>`).join("\n")}
+${uniqueEntries
+  .map(({ path, updated }) => {
+    const lastModified = updated
+      ? `<lastmod>${updated.toISOString().slice(0, 10)}</lastmod>`
+      : "";
+    return `  <url><loc>${xmlEscape(`${base}${path}`)}</loc>${lastModified}</url>`;
+  })
+  .join("\n")}
 </urlset>`;
 
   return new Response(body, {

--- a/src/pages/xiaolin/[slug].astro
+++ b/src/pages/xiaolin/[slug].astro
@@ -2,6 +2,8 @@
 import { getCollection, render } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { absoluteUrl, siteRoot } from "../../lib/seo";
+import "../../styles/xiaolin.css";
+import "../../styles/counterclaw.css";
 
 export async function getStaticPaths() {
   const entries = await getCollection("xiaolin", ({ data }) => data.public && !data.draft);

--- a/src/pages/xiaolin/game-room.astro
+++ b/src/pages/xiaolin/game-room.astro
@@ -1,6 +1,9 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import roomState from "../../data/roomState.json";
+import "../../styles/xiaolin.css";
+import "../../styles/counterclaw.css";
+import "../../styles/game-room.css";
 
 const base = import.meta.env.BASE_URL.endsWith("/") ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
 const withBase = (path: string) => `${base}${path.replace(/^\//, "")}`;

--- a/src/pages/xiaolin/index.astro
+++ b/src/pages/xiaolin/index.astro
@@ -6,6 +6,10 @@ import status from "../../data/xiaolinStatus.json";
 import roomState from "../../data/roomState.json";
 import arenaState from "../../data/arenaState.json";
 import collectiveState from "../../data/collectiveState.json";
+import "../../styles/xiaolin.css";
+import "../../styles/counterclaw.css";
+import "../../styles/arena.css";
+import "../../styles/resident-journal.css";
 
 const notes = (await getCollection("xiaolin", ({ data }) => data.public && !data.draft)).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
@@ -107,7 +111,7 @@ const arenaSchema = {
 
 <BaseLayout
   title="AI 入侵中｜小林房間"
-  description="小林房間的 AI 角色名冊、每日入侵公告、開放式挑戰與逐步突變的競技紀錄。"
+  description="小林房間記錄 AI 角色名冊、每日入侵公告、開放式挑戰、競技突變與共同創作。所有研究連結與資料來源均指向可驗證的公開頁面，虛構角色內容則明確標示。"
   current="xiaolin"
   pageClass="xiaolin-page"
   schema={arenaSchema}

--- a/src/pages/xiaolin/journal/[slug].astro
+++ b/src/pages/xiaolin/journal/[slug].astro
@@ -4,6 +4,8 @@ import BaseLayout from "../../../layouts/BaseLayout.astro";
 import arenaState from "../../../data/arenaState.json";
 import collectiveState from "../../../data/collectiveState.json";
 import { absoluteUrl, siteRoot } from "../../../lib/seo";
+import "../../../styles/xiaolin.css";
+import "../../../styles/resident-journal.css";
 
 export async function getStaticPaths() {
   const entries = await getCollection(

--- a/src/pages/xiaolin/journal/index.astro
+++ b/src/pages/xiaolin/journal/index.astro
@@ -3,6 +3,8 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import arenaState from "../../../data/arenaState.json";
 import collectiveState from "../../../data/collectiveState.json";
+import "../../../styles/xiaolin.css";
+import "../../../styles/resident-journal.css";
 
 const entries = (await getCollection(
   "resident-journal",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,3 @@
-@import "./xiaolin.css";
-@import "./counterclaw.css";
-@import "./game-room.css";
-@import "./arena.css";
-@import "./resident-journal.css";
-
 :root {
   color-scheme: light;
   --page: #f8faf8;


### PR DESCRIPTION
## Summary

- Restore GA4 in the GitHub Pages build and add a regression gate for the deployment variable.
- Rebuild the sitemap from every public Astro collection, add missing static routes and last-modified dates, and exclude the noindex search page.
- Improve canonical, hreflang, Open Graph locale, profile and DefinedTerm metadata.
- Add three source-bounded research answers to the homepage for search intent and E-E-A-T clarity.
- Remove the animated LCP image path, replace homepage GSAP reveals with the Web Animations API, defer nine offscreen video posters, and stop preloading the retrospective video.
- Scope Xiaolin, arena, game-room, and journal CSS to the pages that use it.
- Make the visibility report account for the approximate display width of CJK descriptions.

## Baseline evidence

PageSpeed Insights mobile baseline on 2026-08-20:

- Performance: 71
- SEO: 100
- LCP: 6.1 s
- TBT: 0 ms
- CLS: 0
- LCP element render delay: 4.68 s
- Image-delivery opportunity: 565 KiB
- Console error: the retrospective MP4 was requested during page load

The LCP resource itself loaded in about 180 ms. The dominant issue was the load animation delaying the final paint.

## Verification

- `npm run typecheck`: passed, 0 errors
- Astro production build: passed, 65 pages
- Pagefind build: passed, 65 pages indexed
- Tracking, evidence, answerability, and prose gates: passed
- Visibility dry run: 0 technical blockers, 0 technical warnings
- Sitemap assertion: all 64 indexable HTML routes included, search excluded
- Core Xiaolin, arena, room, and collective tests: 34 passed
- Pumping-game suite: 74 non-browser checks passed; 2 browser checks were not runnable because the local Playwright Chromium executable is unavailable

This is a draft so the public-facing wording can be reviewed before merge.